### PR TITLE
ensure events that happen during construction are correctly processed

### DIFF
--- a/mobius-core/src/test/java/com/spotify/mobius/EventProcessorTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/EventProcessorTest.java
@@ -38,16 +38,18 @@ public class EventProcessorTest {
     effectConsumer = new RecordingConsumer<>();
     stateConsumer = new RecordingConsumer<>();
     underTest = new EventProcessor<>(createStore(), effectConsumer, stateConsumer);
+    underTest.init();
   }
 
   @Test
   public void shouldEmitStateIfStateChanged() throws Exception {
     underTest.update(1);
-    stateConsumer.assertValues("init->1");
+    stateConsumer.assertValues("init!", "init!->1");
   }
 
   @Test
   public void shouldNotEmitStateIfStateNotChanged() throws Exception {
+    stateConsumer.clearValues();
     underTest.update(0);
     stateConsumer.assertValues();
   }
@@ -58,25 +60,38 @@ public class EventProcessorTest {
     underTest.update(1);
     underTest.update(0);
     underTest.update(2);
-    stateConsumer.assertValues("init->1", "init->1->2");
+    stateConsumer.assertValues("init!", "init!->1", "init!->1->2");
   }
 
   @Test
   public void shouldEmitEffectsWhenStateChanges() throws Exception {
+    effectConsumer.clearValues();
     underTest.update(3);
     effectConsumer.assertValuesInAnyOrder(10L, 20L, 30L);
   }
 
   @Test
   public void shouldEmitStateDuringInit() throws Exception {
-    underTest.init();
     stateConsumer.assertValues("init!");
   }
 
   @Test
   public void shouldEmitEffectsDuringInit() throws Exception {
-    underTest.init();
     effectConsumer.assertValuesInAnyOrder(15L, 25L, 35L);
+  }
+
+  @Test
+  public void shouldQueueUpdatesReceivedBeforeInit() throws Exception {
+    stateConsumer.clearValues();
+    underTest = new EventProcessor<>(createStore(), effectConsumer, stateConsumer);
+
+    underTest.update(1);
+    underTest.update(2);
+    underTest.update(3);
+
+    underTest.init();
+
+    stateConsumer.assertValues("init!", "init!->1", "init!->1->2", "init!->1->2->3");
   }
 
   private MobiusStore<String, Integer, Long> createStore() {

--- a/mobius-core/src/test/java/com/spotify/mobius/EventProcessorTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/EventProcessorTest.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.mobius;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.google.common.collect.Sets;
 import com.spotify.mobius.internal_util.ImmutableUtil;
 import com.spotify.mobius.test.RecordingConsumer;
@@ -92,6 +94,11 @@ public class EventProcessorTest {
     underTest.init();
 
     stateConsumer.assertValues("init!", "init!->1", "init!->1->2", "init!->1->2->3");
+  }
+
+  @Test
+  public void shouldDisallowDuplicateInitialisation() throws Exception {
+    assertThatThrownBy(() -> underTest.init()).isInstanceOf(IllegalStateException.class);
   }
 
   private MobiusStore<String, Integer, Long> createStore() {

--- a/mobius-test/src/main/java/com/spotify/mobius/test/RecordingConsumer.java
+++ b/mobius-test/src/main/java/com/spotify/mobius/test/RecordingConsumer.java
@@ -72,4 +72,10 @@ public class RecordingConsumer<V> implements Consumer<V> {
       assertThat(values, containsInAnyOrder(expectedValues));
     }
   }
+
+  public void clearValues() {
+    synchronized (lock) {
+      values.clear();
+    }
+  }
 }

--- a/mobius-test/src/test/java/com/spotify/mobius/test/RecordingConsumerTest.java
+++ b/mobius-test/src/test/java/com/spotify/mobius/test/RecordingConsumerTest.java
@@ -1,0 +1,44 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.test;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class RecordingConsumerTest {
+
+  RecordingConsumer<String> consumer;
+
+  @Before
+  public void setUp() throws Exception {
+    consumer = new RecordingConsumer<>();
+  }
+
+  @Test
+  public void shouldSupportClearingValues() throws Exception {
+    consumer.accept("to be cleared");
+
+    consumer.clearValues();
+
+    consumer.accept("this!");
+
+    consumer.assertValues("this!");
+  }
+}


### PR DESCRIPTION
This commit leads to queuing up events that (due to a race with eventProcessor.init())
arrive before the init call, running them immediately when initialisation is complete.