### PR TITLE
add a couple of tests and fix an InitSpec bug

### DIFF
--- a/mobius-test/src/main/java/com/spotify/mobius/test/InitSpec.java
+++ b/mobius-test/src/main/java/com/spotify/mobius/test/InitSpec.java
@@ -50,11 +50,17 @@ public class InitSpec<M, F> {
 
       @Override
       public void thenError(AssertError assertion) {
+        Exception error = null;
         try {
           init.init(model);
         } catch (Exception e) {
-          assertion.assertError(e);
+          error = e;
         }
+
+        if (error == null) {
+          throw new AssertionError("An exception was expected but was not thrown");
+        }
+        assertion.assertError(error);
       }
     };
   }

--- a/mobius-test/src/main/java/com/spotify/mobius/test/UpdateSpec.java
+++ b/mobius-test/src/main/java/com/spotify/mobius/test/UpdateSpec.java
@@ -149,6 +149,7 @@ public class UpdateSpec<M, E, F> {
       } catch (Exception e) {
         error = e;
       }
+
       if (error == null) {
         throw new AssertionError("An exception was expected but was not thrown");
       }

--- a/mobius-test/src/test/java/com/spotify/mobius/test/InitSpecTest.java
+++ b/mobius-test/src/test/java/com/spotify/mobius/test/InitSpecTest.java
@@ -20,6 +20,7 @@
 package com.spotify.mobius.test;
 
 import static com.spotify.mobius.Effects.effects;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
@@ -59,5 +60,15 @@ public class InitSpecTest {
     initSpec
         .when("bad model")
         .thenError(error -> assertThat(error, instanceOf(IllegalStateException.class)));
+  }
+
+  @Test
+  public void shouldFailIfExpectedErrorDoesntHappen() throws Exception {
+    assertThatThrownBy(
+            () ->
+                initSpec
+                    .when("no crash here")
+                    .thenError(error -> assertThat(error, instanceOf(IllegalStateException.class))))
+        .isInstanceOf(AssertionError.class);
   }
 }

--- a/mobius-test/src/test/java/com/spotify/mobius/test/InitSpecTest.java
+++ b/mobius-test/src/test/java/com/spotify/mobius/test/InitSpecTest.java
@@ -69,6 +69,7 @@ public class InitSpecTest {
                 initSpec
                     .when("no crash here")
                     .thenError(error -> assertThat(error, instanceOf(IllegalStateException.class))))
-        .isInstanceOf(AssertionError.class);
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("An exception was expected but was not thrown");
   }
 }

--- a/mobius-test/src/test/java/com/spotify/mobius/test/UpdateSpecTest.java
+++ b/mobius-test/src/test/java/com/spotify/mobius/test/UpdateSpecTest.java
@@ -26,6 +26,7 @@ import static com.spotify.mobius.test.NextMatchers.hasNothing;
 import static com.spotify.mobius.test.UpdateSpec.assertThatNext;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 import com.spotify.mobius.Next;
@@ -125,5 +126,17 @@ public class UpdateSpecTest {
                     .thenError(e -> assertThat(e.getMessage(), is("expected"))))
         .isInstanceOf(RuntimeException.class)
         .hasMessage("expected");
+  }
+
+  @Test
+  public void shouldFailIfExpectedErrorDoesntHappen() throws Exception {
+    assertThatThrownBy(
+            () ->
+                updateSpec
+                    .given("hi")
+                    .when("no crash here")
+                    .thenError(error -> assertThat(error, instanceOf(IllegalStateException.class))))
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("An exception was expected but was not thrown");
   }
 }


### PR DESCRIPTION
If an exception was expected but didn't happen, InitSpec wouldn't fail. Fixed that and added validation of that behaviour for both InitSpec and UpdateSpec.