### PR TITLE
add a couple of tests for RecordingConsumer

### DIFF
--- a/mobius-test/build.gradle
+++ b/mobius-test/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "org.assertj:assertj-core:${versions.assertjcore}"
     testImplementation "com.google.guava:guava-testlib:${versions.guava}"
+    testImplementation "org.awaitility:awaitility:${versions.awaitility}"
 }
 
 compileJava {


### PR DESCRIPTION
It would be great to specify the intention of the RecondingConsumer API wrt waiting. It currently returns false if it gets interrupted, which doesn't seem that useful? I'm not sure what the original intention is. It seems like it would make more sense to return an indication of whether a new value was received or if it timed out.