### PR TITLE
fix naming issues in Connectables.map

### DIFF
--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/Connectables.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/Connectables.java
@@ -35,7 +35,8 @@ public final class Connectables {
 
   /**
    * Convert a {@code Connectable<I, O>} to a {@code Connectable<J, O>} by applying a function from
-   * J to I for each J received, before invoking the {@code Connectable<I, O>}. This is a <a
+   * J to I for each J received, before invoking the {@code Connectable<I, O>}. This makes {@link
+   * Connectable} a <a
    * href="https://hackage.haskell.org/package/contravariant-1.4.1/docs/Data-Functor-Contravariant.html">contravariant
    * functor</a> in functional programming terms.
    *

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/Connectables.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/Connectables.java
@@ -34,22 +34,22 @@ public final class Connectables {
   }
 
   /**
-   * Convert a {@code Connectable<I, O>} to a {@code Connectable<J, O>} by applying a function from
-   * J to I for each J received, before invoking the {@code Connectable<I, O>}. This makes {@link
-   * Connectable} a <a
+   * Convert a {@code Connectable<I, O>} to a {@code Connectable<J, O>} by applying the supplied
+   * function from J to I for each J received, before passing it on to a {@code Connection<I>}
+   * received from the underlying {@code Connectable<I, O>}. This makes {@link Connectable} a <a
    * href="https://hackage.haskell.org/package/contravariant-1.4.1/docs/Data-Functor-Contravariant.html">contravariant
    * functor</a> in functional programming terms.
    *
-   * <p>This is useful for instance if you want your UI to use a subset or a transformed version of
-   * the full model used in the loop. The returned {@link Connectable} doesn't enforce a connection
-   * limit, but of course the connection limit of the wrapped {@link Connectable} applies.
+   * <p>The returned {@link Connectable} doesn't enforce a connection limit, but of course the
+   * connection limit of the wrapped {@link Connectable} applies.
    *
-   * <p>As a simplified example, suppose that your model consists of a {@code Long} timestamp that
-   * you want to format to a {@code String} before rendering it in the UI. Your UI could then
-   * implement {@code Connectable<String, Event>}, and you could create a {@code Function<Long,
-   * String>} that does the formatting. The {@link com.spotify.mobius.MobiusLoop} would be
-   * outputting {@code Long} models that you need to convert to Strings before they can be accepted
-   * by the UI.
+   * <p>This is useful for instance if you want your UI to use a subset or a transformed version of
+   * the full model used in the {@code MobiusLoop}. As a simplified example, suppose that your model
+   * consists of a {@code Long} timestamp that you want to format to a {@code String} before
+   * rendering it in the UI. Your UI could then implement {@code Connectable<String, Event>}, and
+   * you could create a {@code Function<Long, String>} that does the formatting. The {@link
+   * com.spotify.mobius.MobiusLoop} would be outputting {@code Long} models that you need to convert
+   * to Strings before they can be accepted by the UI.
    *
    * <pre>
    * public class Formatter {

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/Connectables.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/Connectables.java
@@ -34,29 +34,71 @@ public final class Connectables {
   }
 
   /**
-   * Apply a function to a {@link Connectable} in order to convert from one data type to another.
-   * This is useful for instance if you want your UI to use a subset or a transformed version of the
-   * full model used in the loop. The returned {@link Connectable} doesn't enforce a connection
+   * Convert a {@code Connectable<I, O>} to a {@code Connectable<J, O>} by applying a function from
+   * J to I for each J received, before invoking the {@code Connectable<I, O>}. This is a <a
+   * href="https://hackage.haskell.org/package/contravariant-1.4.1/docs/Data-Functor-Contravariant.html">contravariant
+   * functor</a> in functional programming terms.
+   *
+   * <p>This is useful for instance if you want your UI to use a subset or a transformed version of
+   * the full model used in the loop. The returned {@link Connectable} doesn't enforce a connection
    * limit, but of course the connection limit of the wrapped {@link Connectable} applies.
+   *
+   * <p>As a simplified example, suppose that your model consists of a {@code Long} timestamp that
+   * you want to format to a {@code String} before rendering it in the UI. Your UI could then
+   * implement {@code Connectable<String, Event>}, and you could create a {@code Function<Long,
+   * String>} that does the formatting. The {@link com.spotify.mobius.MobiusLoop} would be
+   * outputting {@code Long} models that you need to convert to Strings before they can be accepted
+   * by the UI.
+   *
+   * <pre>
+   * public class Formatter {
+   *    public static String format(Long timestamp) { ... }
+   * }
+   *
+   * public class MyUi implements Connectable<String, Event> {
+   *    // other things in the UI implementation
+   *
+   *   {@literal @}Override
+   *    public Connection<String> connect(Consumer<Event> output) {
+   *       return new Connection<String>() {
+   *        {@literal @}Override
+   *         public void accept(String value) {
+   *           // bind the value to the right UI element
+   *         }
+   *
+   *        {@literal @}Override
+   *         public void dispose() {
+   *           // dispose of any resources, if needed
+   *         }
+   *       }
+   *    }
+   * }
+   *
+   * // Then, to connect the UI to a MobiusLoop.Controller with a Long model:
+   * MobiusLoop.Controller<Long, Event> controller = ... ;
+   * MyUi myUi = ... ;
+   *
+   * controller.connect(Connectables.contramap(Formatter::format, myUi));
+   * </pre>
    *
    * @param mapper the mapping function to apply
    * @param connectable the underlying connectable
-   * @param <F> the type to convert from
-   * @param <T> the type to convert to
+   * @param <I> the type the underlying connectable accepts
+   * @param <J> the type the resulting connectable accepts
    * @param <O> the output type; usually the event type
    */
   @Nonnull
-  public static <F, T, O> Connectable<F, O> convert(
-      final Function<F, T> mapper, final Connectable<T, O> connectable) {
-    return new Connectable<F, O>() {
+  public static <I, J, O> Connectable<J, O> contramap(
+      final Function<J, I> mapper, final Connectable<I, O> connectable) {
+    return new Connectable<J, O>() {
       @Nonnull
       @Override
-      public Connection<F> connect(Consumer<O> output) throws ConnectionLimitExceededException {
-        final Connection<T> delegateConnection = connectable.connect(output);
+      public Connection<J> connect(Consumer<O> output) throws ConnectionLimitExceededException {
+        final Connection<I> delegateConnection = connectable.connect(output);
 
-        return new Connection<F>() {
+        return new Connection<J>() {
           @Override
-          public void accept(F value) {
+          public void accept(J value) {
             delegateConnection.accept(mapper.apply(value));
           }
 

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/Connectables.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/Connectables.java
@@ -41,22 +41,22 @@ public final class Connectables {
    *
    * @param mapper the mapping function to apply
    * @param connectable the underlying connectable
-   * @param <M> the underlying type; usually the model
-   * @param <E> the output type; usually the event type
-   * @param <V> the type to convert to; called V as a mnemonic for ViewData.
+   * @param <F> the type to convert from
+   * @param <T> the type to convert to
+   * @param <O> the output type; usually the event type
    */
   @Nonnull
-  public static <M, E, V> Connectable<M, E> map(
-      final Function<M, V> mapper, final Connectable<V, E> connectable) {
-    return new Connectable<M, E>() {
+  public static <F, T, O> Connectable<F, O> convert(
+      final Function<F, T> mapper, final Connectable<T, O> connectable) {
+    return new Connectable<F, O>() {
       @Nonnull
       @Override
-      public Connection<M> connect(Consumer<E> output) throws ConnectionLimitExceededException {
-        final Connection<V> delegateConnection = connectable.connect(output);
+      public Connection<F> connect(Consumer<O> output) throws ConnectionLimitExceededException {
+        final Connection<T> delegateConnection = connectable.connect(output);
 
-        return new Connection<M>() {
+        return new Connection<F>() {
           @Override
-          public void accept(M value) {
+          public void accept(F value) {
             delegateConnection.accept(mapper.apply(value));
           }
 

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/ConnectablesTest.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/ConnectablesTest.java
@@ -48,7 +48,7 @@ public class ConnectablesTest {
     delegate = new TestConnectable();
     mapParameter = new AtomicReference<>();
     mapped =
-        Connectables.map(
+        Connectables.convert(
             new Function<Double, String>() {
               @Nonnull
               @Override

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/ConnectablesTest.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/ConnectablesTest.java
@@ -48,7 +48,7 @@ public class ConnectablesTest {
     delegate = new TestConnectable();
     mapParameter = new AtomicReference<>();
     mapped =
-        Connectables.convert(
+        Connectables.contramap(
             new Function<Double, String>() {
               @Nonnull
               @Override


### PR DESCRIPTION
- it's not really a 'map' but a 'contramap' - 'convert' is probably a better naming choice
- rename the input parameters to something more generic than M, E, V