### PR TITLE
Effect handler from function

### DIFF
--- a/mobius-rx/build.gradle
+++ b/mobius-rx/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation "com.google.auto.value:auto-value:${versions.autoValue}"
     testImplementation "org.hamcrest:hamcrest-library:${versions.hamcrestLibrary}"
     testImplementation "ch.qos.logback:logback-classic:${versions.logback}"
-
+    testImplementation "org.awaitility:awaitility:${versions.awaitility}"
     apt "com.google.auto.value:auto-value:${versions.autoValue}"
 }
 

--- a/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobius.java
+++ b/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobius.java
@@ -255,6 +255,57 @@ public final class RxMobius {
     }
 
     /**
+     * Add a {@link Func1} for handling effects of a given type. The function will be invoked once
+     * for every received effect object that extend the given class. The returned event will be
+     * forwarded to the Mobius loop.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param function the function that should be invoked for the effect
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+        final Class<G> effectClass, final Func1<G, E> function) {
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(effectClass);
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(function);
+
+      return add(effectClass, Transformers.fromFunction(function));
+    }
+
+    /**
+     * Add a {@link Func1} for handling effects of a given type. The function will be invoked once
+     * for every received effect object that extend the given class. The returned event will be
+     * forwarded to the Mobius loop.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param function the function that should be invoked for the effect
+     * @param scheduler the scheduler that should be used when invoking the function
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+        final Class<G> effectClass, final Func1<G, E> function, Scheduler scheduler) {
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(effectClass);
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(function);
+
+      return add(effectClass, Transformers.fromFunction(function, scheduler));
+    }
+
+    /**
      * Optionally set a shared error handler in case a handler throws an uncaught exception.
      *
      * <p>The default is to use {@link RxJavaHooks#onError(Throwable)}. Note that any exception

--- a/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobius.java
+++ b/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobius.java
@@ -25,6 +25,7 @@ import com.spotify.mobius.ConnectionException;
 import com.spotify.mobius.Mobius;
 import com.spotify.mobius.MobiusLoop;
 import com.spotify.mobius.Update;
+import com.spotify.mobius.functions.Function;
 import java.util.HashMap;
 import java.util.Map;
 import rx.Observable;
@@ -123,8 +124,166 @@ public final class RxMobius {
      * @param <G> the effect class as a type parameter
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
+     * @deprecated use {@link #addTransformer(Class, Transformer)}
      */
+    @Deprecated
     public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+        final Class<G> effectClass, final Transformer<G, E> effectHandler) {
+      return addTransformer(effectClass, effectHandler);
+    }
+
+    /**
+     * Add an {@link Action0} for handling effects of a given type. The action will be invoked once
+     * for every received effect object that extend the given class.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param action the action that should be invoked for the effect
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     * @deprecated use {@link #addAction(Class, Action0)}
+     */
+    @Deprecated
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+        final Class<G> effectClass, final Action0 action) {
+      return addAction(effectClass, action);
+    }
+
+    /**
+     * Add an {@link Action0} for handling effects of a given type. The action will be invoked once
+     * for every received effect object that extend the given class.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param action the action that should be invoked for the effect
+     * @param scheduler the scheduler that should be used to invoke the action
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     * @deprecated use {@link #addAction(Class, Action0, Scheduler)}
+     */
+    @Deprecated
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+        final Class<G> effectClass, final Action0 action, Scheduler scheduler) {
+      return addAction(effectClass, action, scheduler);
+    }
+
+    /**
+     * Add an {@link Action1} for handling effects of a given type. The action will be invoked once
+     * for every received effect object that extend the given class.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param action the action that should be invoked for the effect
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     * @deprecated use {@link #addConsumer(Class, Action1)}
+     */
+    @Deprecated
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+        final Class<G> effectClass, final Action1<G> action) {
+      return addConsumer(effectClass, action);
+    }
+
+    /**
+     * Add an {@link Action1} for handling effects of a given type. The action will be invoked once
+     * for every received effect object that extend the given class.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param action the action that should be invoked for the effect
+     * @param scheduler the scheduler that should be used to invoke the action
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     * @deprecated use {@link #addConsumer(Class, Action1, Scheduler)}
+     */
+    @Deprecated
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+        final Class<G> effectClass, final Action1<G> action, Scheduler scheduler) {
+      return addConsumer(effectClass, action, scheduler);
+    }
+
+    /**
+     * Add a {@link Func1} for handling effects of a given type. The function will be invoked once
+     * for every received effect object that extend the given class. The returned event will be
+     * forwarded to the Mobius loop.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param function the function that should be invoked for the effect
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addFunction(
+        final Class<G> effectClass, final Function<G, E> function) {
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(effectClass);
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(function);
+
+      return addTransformer(effectClass, Transformers.fromFunction(function));
+    }
+
+    /**
+     * Add a {@link Func1} for handling effects of a given type. The function will be invoked once
+     * for every received effect object that extend the given class. The returned event will be
+     * forwarded to the Mobius loop.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param function the function that should be invoked for the effect
+     * @param scheduler the scheduler that should be used when invoking the function
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addFunction(
+        final Class<G> effectClass, final Function<G, E> function, Scheduler scheduler) {
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(effectClass);
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(function);
+
+      return addTransformer(effectClass, Transformers.fromFunction(function, scheduler));
+    }
+
+    /**
+     * Add an {@link Observable.Transformer} for handling effects of a given type. The handler will
+     * receive all effect objects that extend the given class.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the effect class to handle
+     * @param effectHandler the effect handler for the given effect class
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addTransformer(
         final Class<G> effectClass, final Transformer<G, E> effectHandler) {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(effectClass);
@@ -170,14 +329,14 @@ public final class RxMobius {
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
      */
-    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addAction(
         final Class<G> effectClass, final Action0 action) {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(effectClass);
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(action);
 
-      return add(effectClass, Transformers.<G, E>fromAction(action));
+      return addTransformer(effectClass, Transformers.<G, E>fromAction(action));
     }
 
     /**
@@ -195,14 +354,14 @@ public final class RxMobius {
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
      */
-    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addAction(
         final Class<G> effectClass, final Action0 action, Scheduler scheduler) {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(effectClass);
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(action);
 
-      return add(effectClass, Transformers.<G, E>fromAction(action, scheduler));
+      return addTransformer(effectClass, Transformers.<G, E>fromAction(action, scheduler));
     }
 
     /**
@@ -214,19 +373,19 @@ public final class RxMobius {
      * considered a collision.
      *
      * @param effectClass the class to handle
-     * @param action the action that should be invoked for the effect
+     * @param consumer the consumer that should be invoked for the effect
      * @param <G> the effect class as a type parameter
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
      */
-    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
-        final Class<G> effectClass, final Action1<G> action) {
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addConsumer(
+        final Class<G> effectClass, final Action1<G> consumer) {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(effectClass);
       //noinspection ResultOfMethodCallIgnored
-      checkNotNull(action);
+      checkNotNull(consumer);
 
-      return add(effectClass, Transformers.<G, E>fromConsumer(action));
+      return addTransformer(effectClass, Transformers.<G, E>fromConsumer(consumer));
     }
 
     /**
@@ -238,71 +397,20 @@ public final class RxMobius {
      * considered a collision.
      *
      * @param effectClass the class to handle
-     * @param action the action that should be invoked for the effect
+     * @param consumer the consumer that should be invoked for the effect
      * @param scheduler the scheduler that should be used to invoke the action
      * @param <G> the effect class as a type parameter
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
      */
-    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
-        final Class<G> effectClass, final Action1<G> action, Scheduler scheduler) {
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addConsumer(
+        final Class<G> effectClass, final Action1<G> consumer, Scheduler scheduler) {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(effectClass);
       //noinspection ResultOfMethodCallIgnored
-      checkNotNull(action);
+      checkNotNull(consumer);
 
-      return add(effectClass, Transformers.<G, E>fromConsumer(action, scheduler));
-    }
-
-    /**
-     * Add a {@link Func1} for handling effects of a given type. The function will be invoked once
-     * for every received effect object that extend the given class. The returned event will be
-     * forwarded to the Mobius loop.
-     *
-     * <p>Adding handlers for two effect classes where one is a super-class of the other is
-     * considered a collision and is not allowed. Registering the same class twice is also
-     * considered a collision.
-     *
-     * @param effectClass the class to handle
-     * @param function the function that should be invoked for the effect
-     * @param <G> the effect class as a type parameter
-     * @return this builder
-     * @throws IllegalArgumentException if there is a handler collision
-     */
-    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addFunction(
-        final Class<G> effectClass, final Func1<G, E> function) {
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(effectClass);
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(function);
-
-      return add(effectClass, Transformers.fromFunction(function));
-    }
-
-    /**
-     * Add a {@link Func1} for handling effects of a given type. The function will be invoked once
-     * for every received effect object that extend the given class. The returned event will be
-     * forwarded to the Mobius loop.
-     *
-     * <p>Adding handlers for two effect classes where one is a super-class of the other is
-     * considered a collision and is not allowed. Registering the same class twice is also
-     * considered a collision.
-     *
-     * @param effectClass the class to handle
-     * @param function the function that should be invoked for the effect
-     * @param scheduler the scheduler that should be used when invoking the function
-     * @param <G> the effect class as a type parameter
-     * @return this builder
-     * @throws IllegalArgumentException if there is a handler collision
-     */
-    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addFunction(
-        final Class<G> effectClass, final Func1<G, E> function, Scheduler scheduler) {
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(effectClass);
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(function);
-
-      return add(effectClass, Transformers.fromFunction(function, scheduler));
+      return addTransformer(effectClass, Transformers.<G, E>fromConsumer(consumer, scheduler));
     }
 
     /**

--- a/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobius.java
+++ b/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobius.java
@@ -269,7 +269,7 @@ public final class RxMobius {
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
      */
-    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addFunction(
         final Class<G> effectClass, final Func1<G, E> function) {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(effectClass);
@@ -295,7 +295,7 @@ public final class RxMobius {
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
      */
-    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addFunction(
         final Class<G> effectClass, final Func1<G, E> function, Scheduler scheduler) {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(effectClass);

--- a/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobius.java
+++ b/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobius.java
@@ -134,7 +134,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action0} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -155,7 +155,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action0} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -177,7 +177,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action1} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -198,7 +198,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action1} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -220,7 +220,7 @@ public final class RxMobius {
 
     /**
      * Add a {@link Func1} for handling effects of a given type. The function will be invoked once
-     * for every received effect object that extend the given class. The returned event will be
+     * for every received effect object that extends the given class. The returned event will be
      * forwarded to the Mobius loop.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
@@ -245,7 +245,7 @@ public final class RxMobius {
 
     /**
      * Add a {@link Func1} for handling effects of a given type. The function will be invoked once
-     * for every received effect object that extend the given class. The returned event will be
+     * for every received effect object that extends the given class. The returned event will be
      * forwarded to the Mobius loop.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
@@ -317,7 +317,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action0} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -341,7 +341,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action0} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -366,7 +366,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action1} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -390,7 +390,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action1} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also

--- a/mobius-rx/src/main/java/com/spotify/mobius/rx/Transformers.java
+++ b/mobius-rx/src/main/java/com/spotify/mobius/rx/Transformers.java
@@ -19,6 +19,7 @@
  */
 package com.spotify.mobius.rx;
 
+import com.spotify.mobius.functions.Function;
 import com.spotify.mobius.rx.RxMobius.SubtypeEffectHandlerBuilder;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
@@ -136,7 +137,7 @@ class Transformers {
    *     SubtypeEffectHandlerBuilder}.
    */
   static <F, E> Observable.Transformer<F, E> fromFunction(
-      final Func1<F, E> function, @Nullable final Scheduler scheduler) {
+      final Function<F, E> function, @Nullable final Scheduler scheduler) {
     return new Observable.Transformer<F, E>() {
       @Override
       public Observable<E> call(Observable<F> effectStream) {
@@ -149,7 +150,7 @@ class Transformers {
                         new Callable<E>() {
                           @Override
                           public E call() throws Exception {
-                            return function.call(f);
+                            return function.apply(f);
                           }
                         });
                 return scheduler == null ? eventObservable : eventObservable.subscribeOn(scheduler);
@@ -171,7 +172,7 @@ class Transformers {
    * @return an {@link Observable.Transformer} that can be used with a {@link
    *     SubtypeEffectHandlerBuilder}.
    */
-  static <F, E> Observable.Transformer<F, E> fromFunction(final Func1<F, E> function) {
+  static <F, E> Observable.Transformer<F, E> fromFunction(final Function<F, E> function) {
     return fromFunction(function, null);
   }
 }

--- a/mobius-rx/src/test/java/com/spotify/mobius/rx/MobiusEffectRouterTest.java
+++ b/mobius-rx/src/test/java/com/spotify/mobius/rx/MobiusEffectRouterTest.java
@@ -44,7 +44,6 @@ public class MobiusEffectRouterTest {
   private PublishSubject<TestEffect> publishSubject;
   private TestConsumer<C> cConsumer;
   private TestAction dAction;
-  private Func1<E, TestEvent> eFunction = e -> AEvent.create(e.id());
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
@@ -54,11 +53,11 @@ public class MobiusEffectRouterTest {
     dAction = new TestAction();
     Transformer<TestEffect, TestEvent> router =
         RxMobius.<TestEffect, TestEvent>subtypeEffectHandler()
-            .add(A.class, (Transformer<A, TestEvent>) as -> as.map(a -> AEvent.create(a.id())))
-            .add(B.class, (Transformer<B, TestEvent>) bs -> bs.map(b -> BEvent.create(b.id())))
-            .add(C.class, cConsumer)
-            .add(D.class, dAction)
-            .addFunction(E.class, eFunction)
+            .addTransformer(A.class, (Observable<A> as) -> as.map(a -> AEvent.create(a.id())))
+            .addTransformer(B.class, (Observable<B> bs) -> bs.map(b -> BEvent.create(b.id())))
+            .addConsumer(C.class, cConsumer)
+            .addAction(D.class, dAction)
+            .addFunction(E.class, e -> AEvent.create(e.id()))
             .build();
 
     publishSubject = PublishSubject.create();
@@ -118,24 +117,24 @@ public class MobiusEffectRouterTest {
   public void shouldReportEffectClassCollisionWhenAddingSuperclass() throws Exception {
     RxMobius.SubtypeEffectHandlerBuilder<TestEffect, TestEvent> builder =
         RxMobius.<TestEffect, TestEvent>subtypeEffectHandler()
-            .add(Child.class, childObservable -> null);
+            .addTransformer(Child.class, childObservable -> null);
 
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("collision");
 
-    builder.add(Parent.class, parentObservable -> null);
+    builder.addTransformer(Parent.class, parentObservable -> null);
   }
 
   @Test
   public void shouldReportEffectClassCollisionWhenAddingSubclass() throws Exception {
     RxMobius.SubtypeEffectHandlerBuilder<TestEffect, TestEvent> builder =
         RxMobius.<TestEffect, TestEvent>subtypeEffectHandler()
-            .add(Parent.class, observable -> null);
+            .addTransformer(Parent.class, observable -> null);
 
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("collision");
 
-    builder.add(Child.class, observable -> null);
+    builder.addTransformer(Child.class, observable -> null);
   }
 
   @Test
@@ -146,12 +145,12 @@ public class MobiusEffectRouterTest {
 
     RxMobius.SubtypeEffectHandlerBuilder<TestEffect, TestEvent> builder =
         RxMobius.<TestEffect, TestEvent>subtypeEffectHandler()
-            .add(A.class, (Transformer<A, TestEvent>) as -> as.map(a -> AEvent.create(a.id())));
+            .addTransformer(A.class, (Observable<A> as) -> as.map(a -> AEvent.create(a.id())));
 
     Transformer<TestEffect, TestEvent> router = builder.build();
 
     // this should not lead to the effects router being capable of handling B effects
-    builder.add(B.class, (Transformer<B, TestEvent>) bs -> bs.map(b -> BEvent.create(b.id())));
+    builder.addTransformer(B.class, (Observable<B> bs) -> bs.map(b -> BEvent.create(b.id())));
 
     publishSubject.compose(router).subscribe(testSubscriber);
 
@@ -180,12 +179,10 @@ public class MobiusEffectRouterTest {
                   throw expectedException;
                 })
             .withFatalErrorHandler(
-                new Func1<
-                    Observable.Transformer<? extends TestEffect, TestEvent>, Action1<Throwable>>() {
+                new Func1<Transformer<? extends TestEffect, TestEvent>, Action1<Throwable>>() {
                   @Override
                   public Action1<Throwable> call(
-                      Observable.Transformer<? extends TestEffect, TestEvent>
-                          testEventTransformer) {
+                      Transformer<? extends TestEffect, TestEvent> testEventTransformer) {
                     return new Action1<Throwable>() {
                       @Override
                       public void call(Throwable throwable) {

--- a/mobius-rx/src/test/java/com/spotify/mobius/rx/TransformersTest.java
+++ b/mobius-rx/src/test/java/com/spotify/mobius/rx/TransformersTest.java
@@ -19,15 +19,21 @@
  */
 package com.spotify.mobius.rx;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 import com.spotify.mobius.functions.Function;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.awaitility.Duration;
 import org.junit.Before;
 import org.junit.Test;
 import rx.observers.AssertableSubscriber;
+import rx.schedulers.Schedulers;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 
@@ -129,5 +135,36 @@ public class TransformersTest {
     upstream.onNext("Hello");
     scheduler.triggerActions();
     observer.assertError(RuntimeException.class);
+  }
+
+  @Test
+  public void processingLongEffectsDoesNotBlockProcessingShorterEffects() {
+    PublishSubject<String> upstream = PublishSubject.create();
+    Function<String, Integer> function =
+        s -> {
+          int length = s.length();
+          try {
+            Thread.sleep(length * 1000);
+          } catch (InterruptedException ie) {
+          }
+          return length;
+        };
+
+    final List<Integer> results = new ArrayList<>();
+    upstream.compose(Transformers.fromFunction(function, Schedulers.io())).subscribe(results::add);
+
+    String f1 = "Hello";
+    String f2 = "Rx1";
+
+    upstream.onNext(f1); // Will take 5 seconds to process
+    upstream.onNext(f2); // Will take 3 seconds to process
+
+    // Since effects are processed in parallel thanks to FlatMap
+    // Therefore we only wait the max time and add a second to
+    // avoid test flakiness thanks to time
+    int delay = Math.max(f1.length(), f2.length()) + 1;
+    await()
+        .atMost(new Duration(delay, TimeUnit.SECONDS))
+        .until(() -> results.equals(Arrays.asList(3, 5)));
   }
 }

--- a/mobius-rx/src/test/java/com/spotify/mobius/rx/TransformersTest.java
+++ b/mobius-rx/src/test/java/com/spotify/mobius/rx/TransformersTest.java
@@ -23,10 +23,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import com.spotify.mobius.functions.Function;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
-import rx.functions.Func1;
 import rx.observers.AssertableSubscriber;
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
@@ -106,7 +106,7 @@ public class TransformersTest {
   public void effectPerformerInvokesFunctionWithReceivedEffectAndEmitsReturnedEvents() {
     PublishSubject<String> upstream = PublishSubject.create();
     TestScheduler scheduler = new TestScheduler();
-    Func1<String, Integer> function = s -> s.length();
+    Function<String, Integer> function = s -> s.length();
     AssertableSubscriber<Integer> observer =
         upstream.compose(Transformers.fromFunction(function, scheduler)).test();
 
@@ -119,7 +119,7 @@ public class TransformersTest {
   public void effectPerformerInvokesFunctionWithReceivedEffectAndErrorsForUnhandledExceptions() {
     PublishSubject<String> upstream = PublishSubject.create();
     TestScheduler scheduler = new TestScheduler();
-    Func1<String, Integer> function =
+    Function<String, Integer> function =
         s -> {
           throw new RuntimeException("Something bad happened");
         };

--- a/mobius-rx2/build.gradle
+++ b/mobius-rx2/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     testImplementation "com.google.auto.value:auto-value:${versions.autoValue}"
     testImplementation "org.hamcrest:hamcrest-library:${versions.hamcrestLibrary}"
     testImplementation "ch.qos.logback:logback-classic:${versions.logback}"
+    testImplementation "org.awaitility:awaitility:${versions.awaitility}"
 
     apt "com.google.auto.value:auto-value:${versions.autoValue}"
 }

--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
@@ -130,8 +130,29 @@ public final class RxMobius {
      * @param <G> the effect class as a type parameter
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
+     * @deprecated use {@link #addTransformer(Class, ObservableTransformer)}
      */
+    @Deprecated
     public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+        final Class<G> effectClass, final ObservableTransformer<G, E> effectHandler) {
+      return addTransformer(effectClass, effectHandler);
+    }
+
+    /**
+     * Add an {@link ObservableTransformer} for handling effects of a given type. The handler will
+     * receive all effect objects that extend the given class.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param effectHandler the effect handler for the given effect class
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addTransformer(
         final Class<G> effectClass, final ObservableTransformer<G, E> effectHandler) {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(effectClass);
@@ -176,15 +197,12 @@ public final class RxMobius {
      * @param <G> the effect class as a type parameter
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
+     * @deprecated use {@link #addAction(Class, Action)}
      */
+    @Deprecated
     public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
         final Class<G> effectClass, final Action action) {
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(effectClass);
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(action);
-
-      return add(effectClass, Transformers.<G, E>fromAction(action));
+      return addAction(effectClass, action);
     }
 
     /**
@@ -201,15 +219,12 @@ public final class RxMobius {
      * @param <G> the effect class as a type parameter
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
+     * @deprecated use {@link #addAction(Class, Action, Scheduler)}
      */
+    @Deprecated
     public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
         final Class<G> effectClass, final Action action, Scheduler scheduler) {
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(effectClass);
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(action);
-
-      return add(effectClass, Transformers.<G, E>fromAction(action, scheduler));
+      return addAction(effectClass, action, scheduler);
     }
 
     /**
@@ -225,15 +240,12 @@ public final class RxMobius {
      * @param <G> the effect class as a type parameter
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
+     * @deprecated use {@link #addConsumer(Class, Consumer)}
      */
+    @Deprecated
     public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
         final Class<G> effectClass, final Consumer<G> consumer) {
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(effectClass);
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(consumer);
-
-      return add(effectClass, Transformers.<G, E>fromConsumer(consumer));
+      return addConsumer(effectClass, consumer);
     }
 
     /**
@@ -250,15 +262,12 @@ public final class RxMobius {
      * @param <G> the effect class as a type parameter
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
+     * @deprecated use {@link #addConsumer(Class, Consumer, Scheduler)}
      */
+    @Deprecated
     public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
         final Class<G> effectClass, final Consumer<G> consumer, Scheduler scheduler) {
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(effectClass);
-      //noinspection ResultOfMethodCallIgnored
-      checkNotNull(consumer);
-
-      return add(effectClass, Transformers.<G, E>fromConsumer(consumer, scheduler));
+      return addConsumer(effectClass, consumer, scheduler);
     }
 
     /**
@@ -283,7 +292,7 @@ public final class RxMobius {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(function);
 
-      return add(effectClass, Transformers.fromFunction(function));
+      return addTransformer(effectClass, Transformers.fromFunction(function));
     }
 
     /**
@@ -309,7 +318,105 @@ public final class RxMobius {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(function);
 
-      return add(effectClass, Transformers.fromFunction(function, scheduler));
+      return addTransformer(effectClass, Transformers.fromFunction(function, scheduler));
+    }
+
+    /**
+     * Add an {@link Action} for handling effects of a given type. The action will be invoked once
+     * for every received effect object that extend the given class.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param action the action that should be invoked for the effect
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addAction(
+        final Class<G> effectClass, final Action action) {
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(effectClass);
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(action);
+
+      return addTransformer(effectClass, Transformers.<G, E>fromAction(action));
+    }
+
+    /**
+     * Add an {@link Action} for handling effects of a given type. The action will be invoked once
+     * for every received effect object that extend the given class.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param action the action that should be invoked for the effect
+     * @param scheduler the scheduler that should be used to invoke the action
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addAction(
+        final Class<G> effectClass, final Action action, Scheduler scheduler) {
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(effectClass);
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(action);
+
+      return addTransformer(effectClass, Transformers.<G, E>fromAction(action, scheduler));
+    }
+
+    /**
+     * Add an {@link Consumer} for handling effects of a given type. The consumer will be invoked
+     * once for every received effect object that extend the given class.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param consumer the consumer that should be invoked for the effect
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addConsumer(
+        final Class<G> effectClass, final Consumer<G> consumer) {
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(effectClass);
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(consumer);
+
+      return addTransformer(effectClass, Transformers.<G, E>fromConsumer(consumer));
+    }
+
+    /**
+     * Add an {@link Consumer} for handling effects of a given type. The consumer will be invoked
+     * once for every received effect object that extend the given class.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param consumer the consumer that should be invoked for the effect
+     * @param scheduler the scheduler that should be used to invoke the consumer
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addConsumer(
+        final Class<G> effectClass, final Consumer<G> consumer, Scheduler scheduler) {
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(effectClass);
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(consumer);
+
+      return addTransformer(effectClass, Transformers.<G, E>fromConsumer(consumer, scheduler));
     }
 
     /**

--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
@@ -276,7 +276,7 @@ public final class RxMobius {
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
      */
-    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addFunction(
         final Class<G> effectClass, final Function<G, E> function) {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(effectClass);
@@ -302,7 +302,7 @@ public final class RxMobius {
      * @return this builder
      * @throws IllegalArgumentException if there is a handler collision
      */
-    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> addFunction(
         final Class<G> effectClass, final Function<G, E> function, Scheduler scheduler) {
       //noinspection ResultOfMethodCallIgnored
       checkNotNull(effectClass);

--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
@@ -186,7 +186,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -207,7 +207,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -229,7 +229,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Consumer} for handling effects of a given type. The consumer will be invoked
-     * once for every received effect object that extend the given class.
+     * once for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -250,7 +250,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Consumer} for handling effects of a given type. The consumer will be invoked
-     * once for every received effect object that extend the given class.
+     * once for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -272,8 +272,8 @@ public final class RxMobius {
 
     /**
      * Add a {@link Function} for handling effects of a given type. The function will be invoked
-     * once for every received effect object that extend the given class. The returned event will be
-     * forwarded to the Mobius loop.
+     * once for every received effect object that extends the given class. The returned event will
+     * be forwarded to the Mobius loop.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -297,8 +297,8 @@ public final class RxMobius {
 
     /**
      * Add a {@link Function} for handling effects of a given type. The function will be invoked
-     * once for every received effect object that extend the given class. The returned event will be
-     * forwarded to the Mobius loop.
+     * once for every received effect object that extends the given class. The returned event will
+     * be forwarded to the Mobius loop.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -323,7 +323,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -347,7 +347,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Action} for handling effects of a given type. The action will be invoked once
-     * for every received effect object that extend the given class.
+     * for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -372,7 +372,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Consumer} for handling effects of a given type. The consumer will be invoked
-     * once for every received effect object that extend the given class.
+     * once for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also
@@ -396,7 +396,7 @@ public final class RxMobius {
 
     /**
      * Add an {@link Consumer} for handling effects of a given type. The consumer will be invoked
-     * once for every received effect object that extend the given class.
+     * once for every received effect object that extends the given class.
      *
      * <p>Adding handlers for two effect classes where one is a super-class of the other is
      * considered a collision and is not allowed. Registering the same class twice is also

--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
@@ -262,6 +262,57 @@ public final class RxMobius {
     }
 
     /**
+     * Add a {@link Function} for handling effects of a given type. The function will be invoked
+     * once for every received effect object that extend the given class. The returned event will be
+     * forwarded to the Mobius loop.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param function the function that should be invoked for the effect
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+        final Class<G> effectClass, final Function<G, E> function) {
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(effectClass);
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(function);
+
+      return add(effectClass, Transformers.fromFunction(function));
+    }
+
+    /**
+     * Add a {@link Function} for handling effects of a given type. The function will be invoked
+     * once for every received effect object that extend the given class. The returned event will be
+     * forwarded to the Mobius loop.
+     *
+     * <p>Adding handlers for two effect classes where one is a super-class of the other is
+     * considered a collision and is not allowed. Registering the same class twice is also
+     * considered a collision.
+     *
+     * @param effectClass the class to handle
+     * @param function the function that should be invoked for the effect
+     * @param scheduler the scheduler that should be used when invoking the function
+     * @param <G> the effect class as a type parameter
+     * @return this builder
+     * @throws IllegalArgumentException if there is a handler collision
+     */
+    public <G extends F> SubtypeEffectHandlerBuilder<F, E> add(
+        final Class<G> effectClass, final Function<G, E> function, Scheduler scheduler) {
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(effectClass);
+      //noinspection ResultOfMethodCallIgnored
+      checkNotNull(function);
+
+      return add(effectClass, Transformers.fromFunction(function, scheduler));
+    }
+
+    /**
      * Optionally set a shared error handler in case a handler throws an uncaught exception.
      *
      * <p>The default is to use {@link RxJavaPlugins#getErrorHandler()}. Note that any exception

--- a/mobius-rx2/src/test/java/com/spotify/mobius/rx2/TransformersTest.java
+++ b/mobius-rx2/src/test/java/com/spotify/mobius/rx2/TransformersTest.java
@@ -19,14 +19,21 @@
  */
 package com.spotify.mobius.rx2;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.Schedulers;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subjects.PublishSubject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Duration;
 import org.junit.Test;
 
 public class TransformersTest {
@@ -110,5 +117,38 @@ public class TransformersTest {
     upstream.onNext("Hello");
     scheduler.triggerActions();
     observer.assertError(RuntimeException.class);
+  }
+
+  @Test
+  public void processingLongEffectsDoesNotBlockProcessingShorterEffects() {
+    PublishSubject<String> upstream = PublishSubject.create();
+    Function<String, Integer> sleepyFunction =
+        s -> {
+          int length = s.length();
+          try {
+            Thread.sleep(length * 1000);
+          } catch (InterruptedException ie) {
+          }
+          return length;
+        };
+
+    final List<Integer> results = new ArrayList<>();
+    upstream
+        .compose(Transformers.fromFunction(sleepyFunction, Schedulers.io()))
+        .subscribe(results::add);
+
+    String f1 = "Hello";
+    String f2 = "Rx2";
+
+    upstream.onNext(f1); // Will take 5 seconds to process
+    upstream.onNext(f2); // Will take 3 seconds to process
+
+    // Since effects are processed in parallel thanks to FlatMap
+    // Therefore we only wait the max time and add a second to
+    // avoid test flakiness thanks to time
+    int delay = Math.max(f1.length(), f2.length()) + 1;
+    await()
+        .atMost(new Duration(delay, TimeUnit.SECONDS))
+        .until(() -> results.equals(Arrays.asList(3, 5)));
   }
 }


### PR DESCRIPTION
This PR adds the capability to add simple effect handlers in the form of `Function`s. Every time an effect is received, it'll be forwarded to the function. The function can then return an Event which will be emitted back to the loop. This is useful for scenarios where you have simple methods that you need to invoke and then return feedback on the result of this invocation.