### PR TITLE
specify that Connections need to be thread safe in docs

### DIFF
--- a/mobius-core/src/main/java/com/spotify/mobius/Connection.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/Connection.java
@@ -31,7 +31,8 @@ import com.spotify.mobius.functions.Consumer;
 public interface Connection<I> extends Disposable, Consumer<I> {
 
   /**
-   * Send a value this connection.
+   * Send a value this connection. Implementations may receive values from different threads and are
+   * thus expected to be thread-safe.
    *
    * @param value the value that should be sent to the connection
    */


### PR DESCRIPTION
This should be made explicit. I don't believe it necessarily must be documented in the `Consumer` API, but `Connection` is used less generically and it is therefore more important to clarify thread-safety requirements in that context. 