### PR TITLE
remove Guava dependency from mobius-test

### DIFF
--- a/mobius-test/build.gradle
+++ b/mobius-test/build.gradle
@@ -13,14 +13,14 @@ dependencies {
 
     apt "com.google.auto.value:auto-value:${versions.autoValue}"
 
-    implementation "com.google.guava:guava:${versions.guava}"
+    api "com.google.code.findbugs:jsr305:${versions.jsr305}"
+
     implementation "junit:junit:${versions.junit}"
     implementation "org.hamcrest:hamcrest-library:${versions.hamcrestLibrary}"
 
     testImplementation project(':mobius-core')
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "org.assertj:assertj-core:${versions.assertjcore}"
-    testImplementation "com.google.guava:guava-testlib:${versions.guava}"
     testImplementation "org.awaitility:awaitility:${versions.awaitility}"
 }
 

--- a/mobius-test/src/main/java/com/spotify/mobius/test/RecordingConsumer.java
+++ b/mobius-test/src/main/java/com/spotify/mobius/test/RecordingConsumer.java
@@ -23,14 +23,14 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.collect.Lists;
 import com.spotify.mobius.functions.Consumer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public class RecordingConsumer<V> implements Consumer<V> {
 
-  private final List<V> values = Lists.newArrayList();
+  private final List<V> values = new ArrayList<>();
   private final Object lock = new Object();
 
   @Override

--- a/mobius-test/src/main/java/com/spotify/mobius/test/TestWorkRunner.java
+++ b/mobius-test/src/main/java/com/spotify/mobius/test/TestWorkRunner.java
@@ -19,13 +19,13 @@
  */
 package com.spotify.mobius.test;
 
-import com.google.common.collect.Lists;
 import com.spotify.mobius.runners.WorkRunner;
+import java.util.LinkedList;
 import java.util.Queue;
 
 public class TestWorkRunner implements WorkRunner {
 
-  private final Queue<Runnable> queue = Lists.newLinkedList();
+  private final Queue<Runnable> queue = new LinkedList<>();
 
   @Override
   public void post(Runnable runnable) {


### PR DESCRIPTION
It's better to not add a Guava version to dependent projects' class paths, and the usage
was very limited.