### PR TITLE
Add japicmp to test, rx2, rx, extras, and core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - $HOME/.gradle/caches/
 
 script:
-  - ./gradlew check jacocoTestReport
+  - ./gradlew check jacocoTestReport japicmp
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/NOTICE
+++ b/NOTICE
@@ -4,3 +4,5 @@ Copyright 2017-2018 Spotify AB
 This project uses gradle/gradle-mvn-push.gradle from LeakCanary:
 https://github.com/square/leakcanary
 
+This project uses gradle/binary_compatibility.gradle from Groovy1:
+https://github.com/Visistema/Groovy1/

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ subprojects {
                 variant.javaCompiler.dependsOn(rootProject.tasks.format)
             }
         } else if (proj.plugins.findPlugin('java-library')) {
+            proj.apply from: rootProject.file('gradle/binary_compatibility.gradle')
             // for Java (which is easier than android because AGP), ensure compilation is run before
             // formatting, since the compiler has much better error messages for syntax errors.
             rootProject.tasks.format.dependsOn(proj.tasks.compileTestJava)

--- a/gradle/binary_compatibility.gradle
+++ b/gradle/binary_compatibility.gradle
@@ -1,0 +1,42 @@
+// code from: https://github.com/Visistema/Groovy1/blob/ba5eb9b2f19ca0cc8927359ce414c4e1974b7016/gradle/binarycompatibility.gradle#L48
+import me.champeau.gradle.japicmp.JapicmpTask
+
+buildscript {
+    repositories {
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
+    }
+    dependencies {
+        classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.2.6'
+    }
+}
+
+File baselineJar = null
+def baselineVersion = "1.2.0"
+def projectGroup = project.group
+def projectName = project.name
+
+try {
+    String dependency = "$projectGroup:$projectName:$baselineVersion@jar"
+    String jarFile = "$projectName-${baselineVersion}.jar"
+    project.group = 'group_that_does_not_exist'
+
+    baselineJar = files(configurations.detachedConfiguration(
+        dependencies.create(dependency)
+    ).files).filter {
+      it.name.equals(jarFile)
+    }.singleFile
+} finally {
+    project.group = projectGroup
+}
+
+task japicmp(type: JapicmpTask, dependsOn: jar) {
+    oldClasspath = files(baselineJar)
+    newArchives = files(jar.archivePath)
+    newClasspath = configurations.runtimeClasspath
+    onlyModified = true
+    failOnModification = true
+    ignoreMissingClasses = true
+    htmlOutputFile = file("$buildDir/reports/japi.html")
+}


### PR DESCRIPTION
Add japicmp to test, rx2, rx, extras, and core

```
gradle -p mobius-test japicmp ;\
gradle -p mobius-rx2 japicmp ;\
gradle -p mobius-rx japicmp ;\
gradle -p mobius-extras japicmp ;\
gradle -p mobius-core japicmp
```

Adding japicmp via gradle was mentioned on https://github.com/spotify/mobius/issues/40#issuecomment-423736646. I took the implementation from [Visistema/Groovy1](https://github.com/Visistema/Groovy1/blob/ba5eb9b2f19ca0cc8927359ce414c4e1974b7016/gradle/binarycompatibility.gradle#L48).