### PR TITLE
Bump libraries and Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,14 +38,14 @@ ext {
     targetSdkVersion = compileSdkVersion
 
     versions = [
-            'autoValue'        : '1.5',
+            'autoValue'        : '1.5.3',
             'assertjcore'      : '3.8.0',
             'awaitility'       : '3.0.0',
-            'guava'            : '23.0-android',
+            'guava'            : '27.0.1-android',
             'junit'            : '4.12',
             'logback'          : '1.2.3',
-            'rxJava'           : '1.3.4',
-            'rxJava2'          : '2.1.9',
+            'rxJava'           : '1.3.8',
+            'rxJava2'          : '2.2.6',
             'slf4j'            : '1.7.25',
             'jsr305'           : '3.0.1',
             'hamcrestLibrary'  : '1.3',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip


### PR DESCRIPTION
- Update RxJava
- Update AutoValue to latest 1.5.x version
- Update Guava
- Update Gradle to latest 4.x version which includes incremental Java compiling by default