### PR TITLE
improve diagnostics from NextMatchers

### DIFF
--- a/mobius-test/src/main/java/com/spotify/mobius/test/NextMatchers.java
+++ b/mobius-test/src/main/java/com/spotify/mobius/test/NextMatchers.java
@@ -45,18 +45,17 @@ public final class NextMatchers {
       @Override
       protected boolean matchesSafely(Next<M, F> item, Description mismatchDescription) {
         if (item.hasModel()) {
-          mismatchDescription.appendText("has a model");
+          mismatchDescription.appendText("it had a model: " + item.modelUnsafe());
           return false;
 
         } else {
-          mismatchDescription.appendText("no model");
           return true;
         }
       }
 
       @Override
       public void describeTo(Description description) {
-        description.appendText("has no model");
+        description.appendText("Next without model");
       }
     };
   }
@@ -71,19 +70,17 @@ public final class NextMatchers {
     return new TypeSafeDiagnosingMatcher<Next<M, F>>() {
       @Override
       protected boolean matchesSafely(Next<M, F> item, Description mismatchDescription) {
-        if (item.hasModel()) {
-          mismatchDescription.appendText("has a model");
-          return true;
-
-        } else {
-          mismatchDescription.appendText("no model");
+        if (!item.hasModel()) {
+          mismatchDescription.appendText("it had no model");
           return false;
         }
+
+        return true;
       }
 
       @Override
       public void describeTo(Description description) {
-        description.appendText("has a model");
+        description.appendText("Next with any model");
       }
     };
   }
@@ -113,24 +110,22 @@ public final class NextMatchers {
       @Override
       protected boolean matchesSafely(Next<M, F> item, Description mismatchDescription) {
         if (!item.hasModel()) {
-          mismatchDescription.appendText("no model");
+          mismatchDescription.appendText("it had no model");
           return false;
 
         } else if (!matcher.matches(item.modelUnsafe())) {
-          mismatchDescription.appendText("bad model: ");
+          mismatchDescription.appendText("the model ");
           matcher.describeMismatch(item.modelUnsafe(), mismatchDescription);
           return false;
 
         } else {
-          mismatchDescription.appendText("has a model: ");
-          matcher.describeMismatch(item.modelUnsafe(), mismatchDescription);
           return true;
         }
       }
 
       @Override
       public void describeTo(Description description) {
-        description.appendText("has a model: ").appendDescriptionOf(matcher);
+        description.appendText("Next with model ").appendDescriptionOf(matcher);
       }
     };
   }
@@ -146,18 +141,16 @@ public final class NextMatchers {
       @Override
       protected boolean matchesSafely(Next<M, F> item, Description mismatchDescription) {
         if (item.hasEffects()) {
-          mismatchDescription.appendText("has effects");
+          mismatchDescription.appendText("it had effects: " + item.effects());
           return false;
-
         } else {
-          mismatchDescription.appendText("no effects");
           return true;
         }
       }
 
       @Override
       public void describeTo(Description description) {
-        description.appendText("has no effects");
+        description.appendText("Next without effects");
       }
     };
   }
@@ -175,24 +168,20 @@ public final class NextMatchers {
       @Override
       protected boolean matchesSafely(Next<M, F> item, Description mismatchDescription) {
         if (!item.hasEffects()) {
-          mismatchDescription.appendText("no effects");
+          mismatchDescription.appendText("it had no effects");
           return false;
 
         } else if (!matcher.matches(item.effects())) {
-          mismatchDescription.appendText("bad effects: ");
+          mismatchDescription.appendText("the effects were ");
           matcher.describeMismatch(item.effects(), mismatchDescription);
           return false;
-
-        } else {
-          mismatchDescription.appendText("has effects: ");
-          matcher.describeMismatch(item.effects(), mismatchDescription);
-          return true;
         }
+        return true;
       }
 
       @Override
       public void describeTo(Description description) {
-        description.appendText("has effects: ").appendDescriptionOf(matcher);
+        description.appendText("Next with effects ").appendDescriptionOf(matcher);
       }
     };
   }

--- a/mobius-test/src/test/java/com/spotify/mobius/test/NextMatchersTest.java
+++ b/mobius-test/src/test/java/com/spotify/mobius/test/NextMatchersTest.java
@@ -73,10 +73,6 @@ public class NextMatchersTest {
     matcher = hasModel();
 
     assertTrue(matcher.matches(next));
-
-    matcher.describeMismatch(next, desc);
-
-    assertEquals("has a model", desc.toString());
   }
 
   @Test
@@ -88,7 +84,7 @@ public class NextMatchersTest {
 
     matcher.describeMismatch(next, desc);
 
-    assertEquals("no model", desc.toString());
+    assertEquals("it had no model", desc.toString());
   }
 
   @Test
@@ -97,10 +93,6 @@ public class NextMatchersTest {
     matcher = hasNoModel();
 
     assertTrue(matcher.matches(next));
-
-    matcher.describeMismatch(next, desc);
-
-    assertEquals("no model", desc.toString());
   }
 
   @Test
@@ -112,7 +104,7 @@ public class NextMatchersTest {
 
     matcher.describeMismatch(next, desc);
 
-    assertEquals("has a model", desc.toString());
+    assertEquals("it had a model: a", desc.toString());
   }
 
   @Test
@@ -121,10 +113,6 @@ public class NextMatchersTest {
     matcher = hasModel(equalTo("a"));
 
     assertTrue(matcher.matches(next));
-
-    matcher.describeMismatch(next, desc);
-
-    assertEquals("has a model: was \"a\"", desc.toString());
   }
 
   @Test
@@ -133,10 +121,6 @@ public class NextMatchersTest {
     matcher = hasModel("a");
 
     assertTrue(matcher.matches(next));
-
-    matcher.describeMismatch(next, desc);
-
-    assertEquals("has a model: was \"a\"", desc.toString());
   }
 
   @Test
@@ -148,7 +132,7 @@ public class NextMatchersTest {
 
     matcher.describeMismatch(next, desc);
 
-    assertEquals("bad model: was \"b\"", desc.toString());
+    assertEquals("the model was \"b\"", desc.toString());
   }
 
   @Test
@@ -160,7 +144,7 @@ public class NextMatchersTest {
 
     matcher.describeMismatch(next, desc);
 
-    assertEquals("no model", desc.toString());
+    assertEquals("it had no model", desc.toString());
   }
 
   @Test
@@ -169,10 +153,6 @@ public class NextMatchersTest {
     matcher = hasNoEffects();
 
     assertTrue(matcher.matches(next));
-
-    matcher.describeMismatch(next, desc);
-
-    assertEquals("no effects", desc.toString());
   }
 
   @Test
@@ -184,7 +164,7 @@ public class NextMatchersTest {
 
     matcher.describeMismatch(next, desc);
 
-    assertEquals("has effects", desc.toString());
+    assertEquals("it had effects: [1, 2, 3]", desc.toString());
   }
 
   @Test
@@ -193,10 +173,6 @@ public class NextMatchersTest {
     matcher = hasEffects(hasItems(1, 2, 3));
 
     assertTrue(matcher.matches(next));
-
-    matcher.describeMismatch(next, desc);
-
-    assertEquals("has effects: ", desc.toString());
   }
 
   @Test
@@ -208,7 +184,7 @@ public class NextMatchersTest {
 
     matcher.describeMismatch(next, desc);
 
-    assertEquals("bad effects: a collection containing <2> was <1>", desc.toString());
+    assertEquals("the effects were a collection containing <2> was <1>", desc.toString());
   }
 
   @Test
@@ -220,7 +196,7 @@ public class NextMatchersTest {
 
     matcher.describeMismatch(next, desc);
 
-    assertEquals("no effects", desc.toString());
+    assertEquals("it had no effects", desc.toString());
   }
 
   @Test


### PR DESCRIPTION
This improves the readability of many of the error reports. Some examples:

Before
```
Expected: has a model: "foo"
     but: bad model: was "fo"
```

After
```
Expected: Next with model "foo"
     but: the model was "fo"
```

Before
```
Expected: has no effects
     but: has effects
```

After
```
Expected: Next without effects
     but: it had effects: [1]
```

A case that is still problematic (due apparently to how `hasItems` in Hamcrest is implemented) is when effects don't match, but there is arguably a small improvement here as well:

Before
```
Expected: has effects: (a collection containing <1> and a collection containing <2>)
     but: bad effects: a collection containing <1> was <4>, was	<23>
```

After
```
Expected: Next with effects (a collection containing <1> and a collection containing <2>)
     but: the effects were a collection containing <1> was <4>, was <23>
```
