### PR TITLE
Implementations for dimap and merge for Connectables

### DIFF
--- a/mobius-core/src/main/java/com/spotify/mobius/internal_util/Preconditions.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/internal_util/Preconditions.java
@@ -58,4 +58,10 @@ public final class Preconditions {
 
     return input;
   }
+
+  public static void checkArgument(boolean condition) {
+    if (!condition) {
+      throw new IllegalArgumentException();
+    }
+  }
 }

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/Connectables.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/Connectables.java
@@ -52,9 +52,9 @@ public final class Connectables {
    * the full model used in the {@code MobiusLoop}. As a simplified example, suppose that your model
    * consists of a {@code Long} timestamp that you want to format to a {@code String} before
    * rendering it in the UI. Your UI could then implement {@code Connectable<String, Event>}, and
-   * you could create a {@code Function<Long, String>} that does the formatting. The {@link
-   * com.spotify.mobius.MobiusLoop} would be outputting {@code Long} models that you need to convert
-   * to Strings before they can be accepted by the UI.
+   * you could create a {@code NullValuedFunction<Long, String>} that does the formatting. The
+   * {@link com.spotify.mobius.MobiusLoop} would be outputting {@code Long} models that you need to
+   * convert to Strings before they can be accepted by the UI.
    *
    * <pre>
    * public class Formatter {
@@ -159,7 +159,7 @@ public final class Connectables {
    */
   @Nonnull
   public static <A, B, C, D> com.spotify.mobius.Connectable<A, D> dimap(
-      final com.spotify.mobius.extras.Function<A, B> aToB,
+      final NullValuedFunction<A, B> aToB,
       final Function<C, D> cToD,
       final Connectable<B, C> connectable) {
     return SimpleConnectable.withConnectionFactory(

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/Function.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/Function.java
@@ -1,0 +1,28 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras;
+
+import javax.annotation.Nullable;
+
+/** Interface for simple functions that can return null. */
+public interface Function<T, R> {
+  @Nullable
+  R apply(T value);
+}

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/NullValuedFunction.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/NullValuedFunction.java
@@ -22,7 +22,7 @@ package com.spotify.mobius.extras;
 import javax.annotation.Nullable;
 
 /** Interface for simple functions that can return null. */
-public interface Function<T, R> {
+public interface NullValuedFunction<T, R> {
   @Nullable
   R apply(T value);
 }

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/SimpleConnectable.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/SimpleConnectable.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.mobius.extras;
 
+import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
+
 import com.spotify.mobius.Connectable;
 import com.spotify.mobius.Connection;
 import com.spotify.mobius.ConnectionLimitExceededException;
@@ -36,7 +38,7 @@ public final class SimpleConnectable<T, R> implements Connectable<T, R> {
 
   public static <T, R> Connectable<T, R> withConnectionFactory(
       Function<Consumer<R>, Connection<T>> factory) {
-    return new SimpleConnectable<>(factory);
+    return new SimpleConnectable<>(checkNotNull(factory));
   }
 
   private SimpleConnectable(Function<Consumer<R>, Connection<T>> factory) {

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/SimpleConnectable.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/SimpleConnectable.java
@@ -1,0 +1,51 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras;
+
+import com.spotify.mobius.Connectable;
+import com.spotify.mobius.Connection;
+import com.spotify.mobius.ConnectionLimitExceededException;
+import com.spotify.mobius.functions.Consumer;
+import com.spotify.mobius.functions.Function;
+import javax.annotation.Nonnull;
+
+/**
+ * A simple {@link Connectable} implementation that delegates creation of its {@link Connection} to
+ * the specified factory.
+ */
+public final class SimpleConnectable<T, R> implements Connectable<T, R> {
+
+  private final Function<Consumer<R>, Connection<T>> factory;
+
+  public static <T, R> Connectable<T, R> withConnectionFactory(
+      Function<Consumer<R>, Connection<T>> factory) {
+    return new SimpleConnectable<>(factory);
+  }
+
+  private SimpleConnectable(Function<Consumer<R>, Connection<T>> factory) {
+    this.factory = factory;
+  }
+
+  @Nonnull
+  @Override
+  public Connection<T> connect(Consumer<R> output) throws ConnectionLimitExceededException {
+    return factory.apply(output);
+  }
+}

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/ContramapConnection.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/ContramapConnection.java
@@ -1,0 +1,61 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras.connections;
+
+import com.spotify.mobius.Connectable;
+import com.spotify.mobius.Connection;
+import com.spotify.mobius.functions.Consumer;
+import com.spotify.mobius.functions.Function;
+
+/** A {@link Connection} implementation that does contravariant mapping. */
+public class ContramapConnection<A, B, C> implements Connection<B> {
+
+  public static <A, B, C> Connection<B> create(
+      Function<B, A> mapper, Connectable<A, C> connectable, Consumer<C> output) {
+    return new ContramapConnection<>(mapper, connectable, output);
+  }
+
+  private final Function<B, A> mapper;
+  private final Connectable<A, C> connectable;
+  private final Consumer<C> output;
+  private final Connection<A> delegateConnection;
+
+  private ContramapConnection(
+      Function<B, A> mapper, Connectable<A, C> connectable, Consumer<C> output) {
+    this.mapper = mapper;
+    this.connectable = connectable;
+    this.output = output;
+
+    delegateConnection = this.connectable.connect(this.output);
+  }
+
+  @Override
+  public void accept(B j) {
+    final A a = mapper.apply(j);
+    if (a != null) {
+      delegateConnection.accept(a);
+    }
+  }
+
+  @Override
+  public void dispose() {
+    delegateConnection.dispose();
+  }
+}

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/ContramapConnection.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/ContramapConnection.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.mobius.extras.connections;
 
+import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
+
 import com.spotify.mobius.Connectable;
 import com.spotify.mobius.Connection;
 import com.spotify.mobius.functions.Consumer;
@@ -29,7 +31,8 @@ public class ContramapConnection<A, B, C> implements Connection<B> {
 
   public static <A, B, C> Connection<B> create(
       Function<B, A> mapper, Connectable<A, C> connectable, Consumer<C> output) {
-    return new ContramapConnection<>(mapper, connectable, output);
+    return new ContramapConnection<>(
+        checkNotNull(mapper), checkNotNull(connectable), checkNotNull(output));
   }
 
   private final Function<B, A> mapper;

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/ContramapConnection.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/ContramapConnection.java
@@ -51,10 +51,7 @@ public class ContramapConnection<A, B, C> implements Connection<B> {
 
   @Override
   public void accept(B j) {
-    final A a = mapper.apply(j);
-    if (a != null) {
-      delegateConnection.accept(a);
-    }
+    delegateConnection.accept(mapper.apply(j));
   }
 
   @Override

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/DisconnectOnNullDimapConnection.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/DisconnectOnNullDimapConnection.java
@@ -23,30 +23,31 @@ import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
 
 import com.spotify.mobius.Connectable;
 import com.spotify.mobius.Connection;
-import com.spotify.mobius.extras.Function;
+import com.spotify.mobius.extras.NullValuedFunction;
 import com.spotify.mobius.functions.Consumer;
+import com.spotify.mobius.functions.Function;
 
 /** A {@link Connection} that implements dimap. */
 public class DisconnectOnNullDimapConnection<A, B, C, D> implements Connection<A> {
 
   public static <A, B, C, D> Connection<A> create(
-      Function<A, B> aToB,
-      com.spotify.mobius.functions.Function<C, D> cToD,
+      NullValuedFunction<A, B> aToB,
+      Function<C, D> cToD,
       Connectable<B, C> connectable,
       Consumer<D> output) {
     return new DisconnectOnNullDimapConnection<>(
         checkNotNull(aToB), checkNotNull(cToD), checkNotNull(connectable), checkNotNull(output));
   }
 
-  private final Function<A, B> aToB;
-  private final com.spotify.mobius.functions.Function<C, D> cToD;
+  private final NullValuedFunction<A, B> aToB;
+  private final Function<C, D> cToD;
   private final Connectable<B, C> connectable;
   private final Consumer<D> output;
   private Connection<B> currentDelegate;
 
   private DisconnectOnNullDimapConnection(
-      Function<A, B> aToB,
-      com.spotify.mobius.functions.Function<C, D> cToD,
+      NullValuedFunction<A, B> aToB,
+      Function<C, D> cToD,
       Connectable<B, C> connectable,
       Consumer<D> output) {
     this.aToB = aToB;

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/DisconnectOnNullDimapConnection.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/DisconnectOnNullDimapConnection.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.mobius.extras.connections;
 
+import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
+
 import com.spotify.mobius.Connectable;
 import com.spotify.mobius.Connection;
 import com.spotify.mobius.extras.Function;
@@ -32,7 +34,8 @@ public class DisconnectOnNullDimapConnection<A, B, C, D> implements Connection<A
       com.spotify.mobius.functions.Function<C, D> cToD,
       Connectable<B, C> connectable,
       Consumer<D> output) {
-    return new DisconnectOnNullDimapConnection<>(aToB, cToD, connectable, output);
+    return new DisconnectOnNullDimapConnection<>(
+        checkNotNull(aToB), checkNotNull(cToD), checkNotNull(connectable), checkNotNull(output));
   }
 
   private final Function<A, B> aToB;

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/DisconnectOnNullDimapConnection.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/DisconnectOnNullDimapConnection.java
@@ -1,0 +1,83 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras.connections;
+
+import com.spotify.mobius.Connectable;
+import com.spotify.mobius.Connection;
+import com.spotify.mobius.extras.Function;
+import com.spotify.mobius.functions.Consumer;
+
+/** A {@link Connection} that implements dimap. */
+public class DisconnectOnNullDimapConnection<A, B, C, D> implements Connection<A> {
+
+  public static <A, B, C, D> Connection<A> create(
+      Function<A, B> aToB,
+      com.spotify.mobius.functions.Function<C, D> cToD,
+      Connectable<B, C> connectable,
+      Consumer<D> output) {
+    return new DisconnectOnNullDimapConnection<>(aToB, cToD, connectable, output);
+  }
+
+  private final Function<A, B> aToB;
+  private final com.spotify.mobius.functions.Function<C, D> cToD;
+  private final Connectable<B, C> connectable;
+  private final Consumer<D> output;
+  private Connection<B> currentDelegate;
+
+  private DisconnectOnNullDimapConnection(
+      Function<A, B> aToB,
+      com.spotify.mobius.functions.Function<C, D> cToD,
+      Connectable<B, C> connectable,
+      Consumer<D> output) {
+    this.aToB = aToB;
+    this.cToD = cToD;
+    this.connectable = connectable;
+    this.output = output;
+  }
+
+  @Override
+  public void accept(A a) {
+    B b = aToB.apply(a);
+    if (b != null) {
+      if (currentDelegate == null) {
+        currentDelegate =
+            connectable.connect(
+                new Consumer<C>() {
+                  @Override
+                  public void accept(C c) {
+                    final D d = cToD.apply(c);
+                    output.accept(d);
+                  }
+                });
+      }
+      currentDelegate.accept(b);
+    } else if (currentDelegate != null) {
+      currentDelegate.dispose();
+      currentDelegate = null;
+    }
+  }
+
+  @Override
+  public void dispose() {
+    if (currentDelegate != null) {
+      currentDelegate.dispose();
+    }
+  }
+}

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/MergeConnectablesConnection.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/MergeConnectablesConnection.java
@@ -1,0 +1,63 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras.connections;
+
+import com.spotify.mobius.Connectable;
+import com.spotify.mobius.Connection;
+import com.spotify.mobius.functions.Consumer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class MergeConnectablesConnection<A, B> implements Connection<A> {
+
+  private final List<Connection<A>> connections;
+
+  public static <A, B> Connection<A> create(
+      List<Connectable<A, B>> connectables, Consumer<B> output) {
+    return new MergeConnectablesConnection<>(connectables, output);
+  }
+
+  public static <A, B> Connection<A> create(
+      Connectable<A, B> fst, Connectable<A, B> snd, Consumer<B> output) {
+    return create(Arrays.asList(fst, snd), output);
+  }
+
+  private MergeConnectablesConnection(List<Connectable<A, B>> connectables, Consumer<B> output) {
+    connections = new ArrayList<>(connectables.size());
+    for (Connectable<A, B> connectable : connectables) {
+      connections.add(connectable.connect(output));
+    }
+  }
+
+  @Override
+  public synchronized void accept(A value) {
+    for (Connection<A> c : connections) {
+      c.accept(value);
+    }
+  }
+
+  @Override
+  public synchronized void dispose() {
+    for (Connection<A> c : connections) {
+      c.dispose();
+    }
+  }
+}

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/package-info.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/connections/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+@ParametersAreNonnullByDefault
+package com.spotify.mobius.extras.connections;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/DisconnectOnNullDimapConnectableTest.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/DisconnectOnNullDimapConnectableTest.java
@@ -1,0 +1,144 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras;
+
+import static com.spotify.mobius.extras.TestConnectable.State.CONNECTED;
+import static com.spotify.mobius.extras.TestConnectable.State.DISPOSED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.spotify.mobius.Connectable;
+import com.spotify.mobius.Connection;
+import com.spotify.mobius.extras.domain.A;
+import com.spotify.mobius.extras.domain.B;
+import com.spotify.mobius.extras.domain.C;
+import com.spotify.mobius.extras.domain.D;
+import com.spotify.mobius.test.RecordingConsumer;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DisconnectOnNullDimapConnectableTest {
+  private TestConnectable connectable;
+  private Connectable<A, D> underTest;
+  private RecordingConsumer<D> recorder;
+  private Connection<A> connection;
+
+  @Before
+  public void setUp() {
+    connectable = TestConnectable.createWithReversingTransformation();
+    underTest = Connectables.dimap(A::b, D::create, connectable);
+    recorder = new RecordingConsumer<>();
+  }
+
+  @Test
+  public void doesNothingIfWrappingConnectableIsntConnected() {
+    assertNull(connectable.state);
+  }
+
+  @Test
+  public void connectsToTargetWhenReceivingNonnullValue() {
+    connect();
+    connection.accept(A.create(B.create("Hello")));
+    assertEquals(CONNECTED, connectable.state);
+  }
+
+  @Test
+  public void connectsToTargetOnlyOnReceivingFirstNonnullValue() {
+    connect();
+    connection.accept(A.create(B.create("Hello")));
+    connection.accept(A.create(B.create("World")));
+    assertEquals(CONNECTED, connectable.state);
+    assertEquals(1, connectable.connectionsCount);
+  }
+
+  @Test
+  public void doesNotConnectToTargetOnReceivingNullValues() {
+    connect();
+    connection.accept(A.create(null));
+    assertNull(connectable.state);
+    assertEquals(0, connectable.connectionsCount);
+  }
+
+  @Test
+  public void disconnectsFromTargetAfterReceivingNullValue() {
+    connect();
+    connection.accept(A.create(B.create("Hello")));
+    assertEquals(CONNECTED, connectable.state);
+    connection.accept(A.create(null));
+    assertEquals(DISPOSED, connectable.state);
+  }
+
+  @Test
+  public void reconnectsOnValidValuesAfterDisconnectingFromTarget() {
+    connect();
+    connection.accept(A.create(B.create("Hello")));
+    assertEquals(CONNECTED, connectable.state);
+    connection.accept(A.create(null));
+    assertEquals(DISPOSED, connectable.state);
+
+    connection.accept(A.create(B.create("World")));
+    assertEquals(CONNECTED, connectable.state);
+  }
+
+  @Test
+  public void connectionDisposalPropagatesToWrappedConnectable() {
+    connect();
+    connection.accept(A.create(B.create("Hello")));
+    assertEquals(CONNECTED, connectable.state);
+    connection.dispose();
+    assertEquals(DISPOSED, connectable.state);
+  }
+
+  @Test
+  public void connectionDisposalWithoutBeingConnectedToWrappedConnectableDoesNothing() {
+    connect();
+    connection.dispose();
+    assertNull(connectable.state);
+  }
+
+  @Test
+  public void unpacksAndDelegatesToChildConnectableAndMapsChildOutput() {
+    connect();
+    connection.accept(A.create(B.create("Hello")));
+    recorder.assertValues(D.create(C.create("olleH")));
+  }
+
+  @Test
+  public void unpacksAndDelegatesToChildConnectableAndMapsChildOutputMultipleTimes() {
+    connect();
+    connection.accept(A.create(B.create("Hello")));
+    connection.accept(A.create(B.create("World")));
+    recorder.assertValues(D.create(C.create("olleH")), D.create(C.create("dlroW")));
+  }
+
+  @Test
+  public void
+      unpacksAndDelegatesToChildConnectableAndMapsChildOutputMultipleTimesWithDisconnectingBetweenItems() {
+    connect();
+    connection.accept(A.create(B.create("Hello")));
+    connection.accept(A.create(null));
+    connection.accept(A.create(B.create("World")));
+    recorder.assertValues(D.create(C.create("olleH")), D.create(C.create("dlroW")));
+  }
+
+  private void connect() {
+    connection = underTest.connect(recorder);
+  }
+}

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/MergeConnectablesTest.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/MergeConnectablesTest.java
@@ -21,6 +21,7 @@ package com.spotify.mobius.extras;
 
 import static com.spotify.mobius.extras.TestConnectable.State.CONNECTED;
 import static com.spotify.mobius.extras.TestConnectable.State.DISPOSED;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
 import com.spotify.mobius.Connectable;
@@ -75,6 +76,15 @@ public class MergeConnectablesTest {
     connect();
     connection.accept(B.create("Hello"));
     consumer.assertValues(C.create("olleH"), C.create("hello"));
+  }
+
+  @Test
+  public void acceptingValuesAfterDisposalThrowsException() {
+    connect();
+    connection.dispose();
+    assertThatThrownBy(
+            () -> connection.accept(B.create("I know I shouldn't do this, but I am anyway!")))
+        .isInstanceOf(IllegalStateException.class);
   }
 
   private void connect() {

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/MergeConnectablesTest.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/MergeConnectablesTest.java
@@ -1,0 +1,83 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras;
+
+import static com.spotify.mobius.extras.TestConnectable.State.CONNECTED;
+import static com.spotify.mobius.extras.TestConnectable.State.DISPOSED;
+import static org.junit.Assert.assertEquals;
+
+import com.spotify.mobius.Connectable;
+import com.spotify.mobius.Connection;
+import com.spotify.mobius.extras.domain.B;
+import com.spotify.mobius.extras.domain.C;
+import com.spotify.mobius.test.RecordingConsumer;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MergeConnectablesTest {
+  TestConnectable c1;
+  TestConnectable c2;
+  RecordingConsumer<C> consumer;
+  private Connectable<B, C> merged;
+  private Connection<B> connection;
+
+  @Before
+  public void setUp() throws Exception {
+    c1 = TestConnectable.createWithReversingTransformation();
+    c2 = TestConnectable.create(String::toLowerCase);
+    consumer = new RecordingConsumer<>();
+    merged = Connectables.merge(c1, c2);
+  }
+
+  @Test
+  public void propagatesConnectionImmediately() {
+    connect();
+    assertEquals(CONNECTED, c1.state);
+    assertEquals(CONNECTED, c2.state);
+  }
+
+  @Test
+  public void propagatesMultipleConnections() {
+    final Connection<B> conn1 = merged.connect(consumer);
+    final Connection<B> conn2 = merged.connect(consumer);
+
+    assertEquals(2, c1.connectionsCount);
+    assertEquals(2, c2.connectionsCount);
+  }
+
+  @Test
+  public void propagatesConnectionDisposal() {
+    connect();
+    connection.dispose();
+    assertEquals(DISPOSED, c1.state);
+    assertEquals(DISPOSED, c2.state);
+  }
+
+  @Test
+  public void appliesBothChildrenOnInputAndForwardsOutput() {
+    connect();
+    connection.accept(B.create("Hello"));
+    consumer.assertValues(C.create("olleH"), C.create("hello"));
+  }
+
+  private void connect() {
+    connection = merged.connect(consumer);
+  }
+}

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/TestConnectable.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/TestConnectable.java
@@ -1,0 +1,75 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras;
+
+import static com.spotify.mobius.extras.TestConnectable.State.CONNECTED;
+import static com.spotify.mobius.extras.TestConnectable.State.DISPOSED;
+
+import com.spotify.mobius.Connectable;
+import com.spotify.mobius.Connection;
+import com.spotify.mobius.extras.domain.B;
+import com.spotify.mobius.extras.domain.C;
+import com.spotify.mobius.functions.Consumer;
+import com.spotify.mobius.functions.Function;
+import javax.annotation.Nonnull;
+
+class TestConnectable implements Connectable<B, C> {
+
+  enum State {
+    DISPOSED,
+    CONNECTED
+  }
+
+  private final com.spotify.mobius.functions.Function<String, String> transform;
+
+  State state;
+  int connectionsCount;
+
+  public static TestConnectable create(Function<String, String> transform) {
+    return new TestConnectable(transform);
+  }
+
+  public static TestConnectable createWithReversingTransformation() {
+    return create(value -> new StringBuilder(value).reverse().toString());
+  }
+
+  TestConnectable(Function<String, String> transform) {
+    this.transform = transform;
+  }
+
+  @Nonnull
+  @Override
+  public Connection<B> connect(Consumer<C> output) {
+    state = CONNECTED;
+    connectionsCount++;
+    return new Connection<B>() {
+      @Override
+      public void accept(B value) {
+        output.accept(C.create(transform.apply(value.something())));
+      }
+
+      @Override
+      public void dispose() {
+        state = DISPOSED;
+        connectionsCount--;
+      }
+    };
+  }
+}

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/domain/A.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/domain/A.java
@@ -1,0 +1,33 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras.domain;
+
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class A {
+  @Nullable
+  public abstract B b();
+
+  public static A create(@Nullable B b) {
+    return new AutoValue_A(b);
+  }
+}

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/domain/B.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/domain/B.java
@@ -1,0 +1,31 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras.domain;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class B {
+  public abstract String something();
+
+  public static B create(String something) {
+    return new AutoValue_B(something);
+  }
+}

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/domain/C.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/domain/C.java
@@ -1,0 +1,31 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras.domain;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class C {
+  public abstract String somethingElse();
+
+  public static C create(String somethingElse) {
+    return new AutoValue_C(somethingElse);
+  }
+}

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/domain/D.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/domain/D.java
@@ -1,0 +1,31 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras.domain;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class D {
+  public abstract C c();
+
+  public static D create(C c) {
+    return new AutoValue_D(c);
+  }
+}


### PR DESCRIPTION
1. Merge: Merges multiple connectables of the same types into one
2. Dimap: Useful for composing connectables. Is the equivalent of applying `contramap` for the inputs, then `map` for the outputs.