### PR TITLE
Added startFrom(M, Set<F>) and moved init in Controller

### DIFF
--- a/mobius-android/src/main/java/com/spotify/mobius/android/MobiusAndroid.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MobiusAndroid.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.mobius.android;
 
+import com.spotify.mobius.First;
+import com.spotify.mobius.Init;
 import com.spotify.mobius.Mobius;
 import com.spotify.mobius.MobiusLoop;
 import com.spotify.mobius.android.runners.MainThreadWorkRunner;
@@ -30,6 +32,12 @@ public final class MobiusAndroid {
 
   public static <M, E, F> MobiusLoop.Controller<M, E> controller(
       MobiusLoop.Factory<M, E, F> loopFactory, M defaultModel) {
-    return Mobius.controller(loopFactory, defaultModel, MainThreadWorkRunner.create());
+    return Mobius.<M, E, F>controller(
+        loopFactory, defaultModel, First::first, MainThreadWorkRunner.create());
+  }
+
+  public static <M, E, F> MobiusLoop.Controller<M, E> controller(
+      MobiusLoop.Factory<M, E, F> loopFactory, M defaultModel, Init<M, F> init) {
+    return Mobius.controller(loopFactory, defaultModel, init, MainThreadWorkRunner.create());
   }
 }

--- a/mobius-core/src/main/java/com/spotify/mobius/ControllerStateRunning.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/ControllerStateRunning.java
@@ -32,12 +32,15 @@ class ControllerStateRunning<M, E, F> extends ControllerStateBase<M, E> {
       ControllerActions<M, E> actions,
       Connection<M> renderer,
       MobiusLoop.Factory<M, E, F> loopFactory,
-      M modelToStartFrom) {
+      M modelToStartFrom,
+      Init<M, F> init) {
+
+    First<M, F> first = init.init(modelToStartFrom);
 
     this.actions = actions;
     this.renderer = renderer;
-    this.loop = loopFactory.startFrom(modelToStartFrom);
-    this.startModel = modelToStartFrom;
+    this.loop = loopFactory.startFrom(first.model(), first.effects());
+    this.startModel = first.model();
   }
 
   void start() {

--- a/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
@@ -138,7 +138,21 @@ public final class Mobius {
    */
   public static <M, E, F> MobiusLoop.Controller<M, E> controller(
       MobiusLoop.Factory<M, E, F> loopFactory, M defaultModel) {
-    return new MobiusLoopController<>(loopFactory, defaultModel, WorkRunners.immediate());
+    return new MobiusLoopController<>(
+        loopFactory, defaultModel, model -> First.<M, F>first(model), WorkRunners.immediate());
+  }
+
+  /**
+   * Create a {@link MobiusLoop.Controller} that allows you to start, stop, and restart MobiusLoops.
+   *
+   * @param loopFactory a factory for creating loops
+   * @param defaultModel the model the controller should start from
+   * @param init the init function to run when a loop starts
+   * @return a new controller
+   */
+  public static <M, E, F> MobiusLoop.Controller<M, E> controller(
+      MobiusLoop.Factory<M, E, F> loopFactory, M defaultModel, Init<M, F> init) {
+    return new MobiusLoopController<>(loopFactory, defaultModel, init, WorkRunners.immediate());
   }
 
   /**
@@ -151,7 +165,25 @@ public final class Mobius {
    */
   public static <M, E, F> MobiusLoop.Controller<M, E> controller(
       MobiusLoop.Factory<M, E, F> loopFactory, M defaultModel, WorkRunner modelRunner) {
-    return new MobiusLoopController<>(loopFactory, defaultModel, modelRunner);
+    return new MobiusLoopController<>(
+        loopFactory, defaultModel, model -> First.<M, F>first(model), modelRunner);
+  }
+
+  /**
+   * Create a {@link MobiusLoop.Controller} that allows you to start, stop, and restart MobiusLoops.
+   *
+   * @param loopFactory a factory for creating loops
+   * @param defaultModel the model the controller should start from
+   * @param init the init function to run when a loop starts
+   * @param modelRunner the WorkRunner to use when observing model changes
+   * @return a new controller
+   */
+  public static <M, E, F> MobiusLoop.Controller<M, E> controller(
+      MobiusLoop.Factory<M, E, F> loopFactory,
+      M defaultModel,
+      Init<M, F> init,
+      WorkRunner modelRunner) {
+    return new MobiusLoopController<>(loopFactory, defaultModel, init, modelRunner);
   }
 
   private static final class Builder<M, E, F> implements MobiusLoop.Builder<M, E, F> {

--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusLoop.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusLoop.java
@@ -26,6 +26,7 @@ import com.spotify.mobius.functions.Consumer;
 import com.spotify.mobius.functions.Producer;
 import com.spotify.mobius.runners.WorkRunner;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -218,10 +219,12 @@ public class MobiusLoop<M, E, F> implements Disposable {
   public interface Builder<M, E, F> extends Factory<M, E, F> {
 
     /**
+     * @deprecated Pass your initial effects to {@link #startFrom(Object, Set)} instead.
      * @return a new {@link Builder} with the supplied {@link Init}, and the same values as the
      *     current one for the other fields.
      */
     @Nonnull
+    @Deprecated
     Builder<M, E, F> init(Init<M, F> init);
 
     /**
@@ -283,6 +286,15 @@ public class MobiusLoop<M, E, F> implements Disposable {
      * @return the started {@link MobiusLoop}
      */
     MobiusLoop<M, E, F> startFrom(M startModel);
+
+    /**
+     * Start a {@link MobiusLoop} using this factory.
+     *
+     * @param startModel the model that the loop should start from
+     * @param startEffects the effects that the loop should start with
+     * @return the started {@link MobiusLoop}
+     */
+    MobiusLoop<M, E, F> startFrom(M startModel, Set<F> startEffects);
   }
 
   /**

--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusLoopController.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusLoopController.java
@@ -31,15 +31,20 @@ class MobiusLoopController<M, E, F>
 
   private final MobiusLoop.Factory<M, E, F> loopFactory;
   private final M defaultModel;
+  private final Init<M, F> init;
   private final WorkRunner mainThreadRunner;
 
   private ControllerStateBase<M, E> currentState;
 
   MobiusLoopController(
-      MobiusLoop.Factory<M, E, F> loopFactory, M defaultModel, WorkRunner mainThreadRunner) {
+      MobiusLoop.Factory<M, E, F> loopFactory,
+      M defaultModel,
+      Init<M, F> init,
+      WorkRunner mainThreadRunner) {
 
     this.loopFactory = checkNotNull(loopFactory);
     this.defaultModel = checkNotNull(defaultModel);
+    this.init = checkNotNull(init);
     this.mainThreadRunner = checkNotNull(mainThreadRunner);
     goToStateInit(defaultModel);
   }
@@ -135,7 +140,7 @@ class MobiusLoopController<M, E, F>
   @Override
   public synchronized void goToStateRunning(Connection<M> renderer, M nextModelToStartFrom) {
     ControllerStateRunning<M, E, F> stateRunning =
-        new ControllerStateRunning<>(this, renderer, loopFactory, nextModelToStartFrom);
+        new ControllerStateRunning<>(this, renderer, loopFactory, nextModelToStartFrom, init);
 
     currentState = stateRunning;
 

--- a/mobius-core/src/test/java/com/spotify/mobius/MobiusLoopControllerTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/MobiusLoopControllerTest.java
@@ -71,14 +71,13 @@ public class MobiusLoopControllerTest {
 
   public static class Lifecycle {
 
-    private final MobiusLoopController<String, String, String> underTest =
-        new MobiusLoopController<>(
+    private final MobiusLoop.Controller<String, String> underTest =
+        Mobius.controller(
             Mobius.<String, String, String>loop(
                     (model, event) -> Next.next(model + event), effectHandler)
                 .eventRunner(WorkRunners::immediate)
                 .effectRunner(WorkRunners::immediate),
-            "init",
-            WorkRunners.immediate());
+            "init");
 
     @Test
     public void canCreateView() throws Exception {
@@ -196,14 +195,13 @@ public class MobiusLoopControllerTest {
 
   public static class StateSaveRestore {
 
-    private final MobiusLoopController<String, String, String> underTest =
-        new MobiusLoopController<>(
+    private final MobiusLoop.Controller<String, String> underTest =
+        Mobius.controller(
             Mobius.<String, String, String>loop(
                     (model, event) -> Next.next(model + event), effectHandler)
                 .eventRunner(WorkRunners::immediate)
                 .effectRunner(WorkRunners::immediate),
-            "init",
-            WorkRunners.immediate());
+            "init");
 
     @Test
     public void canSaveState() throws Exception {
@@ -283,15 +281,13 @@ public class MobiusLoopControllerTest {
 
   public static class Loop {
 
-    private final MobiusLoopController<String, String, String> underTest =
-        new MobiusLoopController<>(
+    private final MobiusLoop.Controller<String, String> underTest =
+        Mobius.controller(
             Mobius.<String, String, String>loop(
                     (model, event) -> Next.next(model + event), effectHandler)
                 .eventRunner(WorkRunners::immediate)
-                .effectRunner(WorkRunners::immediate)
-                .init(First::first),
-            "init",
-            WorkRunners.immediate());
+                .effectRunner(WorkRunners::immediate),
+            "init");
 
     @Test
     public void startsFromDefaultModel() throws Exception {
@@ -343,15 +339,13 @@ public class MobiusLoopControllerTest {
   }
 
   public static class Connect {
-    private final MobiusLoopController<String, String, String> underTest =
-        new MobiusLoopController<>(
+    private final MobiusLoop.Controller<String, String> underTest =
+        Mobius.controller(
             Mobius.<String, String, String>loop(
                     (model, event) -> Next.next(model + event), effectHandler)
                 .eventRunner(WorkRunners::immediate)
-                .effectRunner(WorkRunners::immediate)
-                .init(First::first),
-            "init",
-            WorkRunners.immediate());
+                .effectRunner(WorkRunners::immediate),
+            "init");
 
     @Test
     public void modelHandlerMustReturnConsumer() throws Exception {
@@ -411,21 +405,22 @@ public class MobiusLoopControllerTest {
   public static class EventsAndUpdates {
     private final WorkRunner mainThreadRunner = new ImmediateWorkRunner();
 
-    private MobiusLoopController<String, String, String> underTest;
+    private MobiusLoop.Controller<String, String> underTest;
 
     @Before
     public void setUp() throws Exception {
       underTest = createWithWorkRunner(mainThreadRunner);
     }
 
-    private MobiusLoopController<String, String, String> createWithWorkRunner(
+    private MobiusLoop.Controller<String, String> createWithWorkRunner(
         WorkRunner mainThreadRunner) {
-      return new MobiusLoopController<>(
+      return Mobius.<String, String, String>controller(
           Mobius.<String, String, String>loop(
                   (model, event) -> Next.next(model + event), effectHandler)
               .eventRunner(WorkRunners::immediate)
               .effectRunner(WorkRunners::immediate),
           "init",
+          First::first,
           mainThreadRunner);
     }
 


### PR DESCRIPTION
This is the second step in moving init to `MobiusLoop.Controller`

Init still remains on MobiusLoop.Builder for API compatibility, but it's marked as deprecated and should be removed in the next major release. The preferred way to initialize a loop is now to either pass in effects directly when starting the loop, or to pass an `init` function to a MobiusLoop.Controller.