### PR TITLE
Trim quotes from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,17 +4,17 @@ GROUP=com.spotify.mobius
 
 POM_DESCRIPTION=Mobius
 
-POM_URL="https://github.com/spotify/mobius/"
-POM_SCM_URL="https://github.com/spotify/mobius/"
-POM_SCM_CONNECTION="scm:git@github.com:spotify/mobius.git"
-POM_SCM_DEV_CONNECTION="scm:git@github.com:spotify/mobius.git"
+POM_URL=https://github.com/spotify/mobius/
+POM_SCM_URL=https://github.com/spotify/mobius/
+POM_SCM_CONNECTION=scm:git@github.com:spotify/mobius.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:spotify/mobius.git
 
-POM_LICENCE_NAME="The Apache Software License, Version 2.0"
-POM_LICENCE_URL="http://www.apache.org/licenses/LICENSE-2.0.txt"
-POM_LICENCE_DIST="repo"
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
 
-POM_DEVELOPER_ID="spotify"
-POM_DEVELOPER_NAME="Spotify AB"
+POM_DEVELOPER_ID=spotify
+POM_DEVELOPER_NAME=Spotify AB
 
 org.gradle.caching=true
 org.gradle.configureondemand=true


### PR DESCRIPTION
In properties files, the quotes are a part of the value ([see HomePage](https://mvnrepository.com/artifact/com.spotify.mobius/mobius-core/1.3.0)).  Besides not being clean, this also has a real impact on tools such as dependency license generators, for example with [gradle-license-plugin](https://github.com/jaredsburrows/gradle-license-plugin) I'm seeing:

```
> Task :app:licenseDebugReport
RxJava2 tools for Mobius dependency has an invalid license URL; skipping license
RxJava2 tools for Mobius dependency does not have a license.
Android-specific part of Mobius dependency has an invalid license URL; skipping license
Android-specific part of Mobius dependency does not have a license.
Mobius Core dependency has an invalid license URL; skipping license
Mobius Core dependency does not have a license.
```