### PR TITLE
Changed the first model update and effect dispatching to be synchronous.

### DIFF
--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusLoop.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusLoop.java
@@ -131,16 +131,10 @@ public class MobiusLoop<M, E, F> implements Disposable {
 
     mostRecentModel = startModel;
 
-    eventRunner.post(
-        new Runnable() {
-          @Override
-          public void run() {
-            onModelChanged.accept(startModel);
-            for (F effect : startEffects) {
-              effectDispatcher.accept(effect);
-            }
-          }
-        });
+    onModelChanged.accept(startModel);
+    for (F effect : startEffects) {
+      effectDispatcher.accept(effect);
+    }
   }
 
   public void dispatchEvent(E event) {

--- a/mobius-core/src/test/java/com/spotify/mobius/MobiusLoopDisposalBehavior.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/MobiusLoopDisposalBehavior.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.util.concurrent.SettableFuture;
 import com.spotify.mobius.disposables.Disposable;
 import com.spotify.mobius.functions.Consumer;
-import com.spotify.mobius.runners.WorkRunner;
 import com.spotify.mobius.test.RecordingConsumer;
 import com.spotify.mobius.test.RecordingModelObserver;
 import com.spotify.mobius.test.TestWorkRunner;
@@ -168,9 +167,7 @@ public class MobiusLoopDisposalBehavior extends MobiusLoopTest {
         };
 
     final MobiusLoop.Builder<String, TestEvent, TestEffect> builder =
-        Mobius.loop(update, effectHandler)
-            .eventRunner(
-                () -> InitImmediatelyThenUpdateConcurrentlyWorkRunner.create(backgroundRunner));
+        Mobius.loop(update, effectHandler);
 
     mobiusLoop = builder.startFrom("foo");
     mobiusLoop.observe(observer);
@@ -346,36 +343,6 @@ public class MobiusLoopDisposalBehavior extends MobiusLoopTest {
           }
         }
       }
-    }
-  }
-
-  static class InitImmediatelyThenUpdateConcurrentlyWorkRunner implements WorkRunner {
-    private final WorkRunner delegate;
-
-    private boolean ranOnce;
-
-    private InitImmediatelyThenUpdateConcurrentlyWorkRunner(WorkRunner delegate) {
-      this.delegate = delegate;
-    }
-
-    public static WorkRunner create(WorkRunner eventRunner) {
-      return new InitImmediatelyThenUpdateConcurrentlyWorkRunner(eventRunner);
-    }
-
-    @Override
-    public synchronized void post(Runnable runnable) {
-      if (ranOnce) {
-        delegate.post(runnable);
-        return;
-      }
-
-      ranOnce = true;
-      runnable.run();
-    }
-
-    @Override
-    public void dispose() {
-      delegate.dispose();
     }
   }
 }

--- a/mobius-core/src/test/java/com/spotify/mobius/MobiusTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/MobiusTest.java
@@ -117,8 +117,7 @@ public class MobiusTest {
 
     loop.dispatchEvent(3);
 
-    // 2 because the initial model dispatch is run on the event runner
-    await().atMost(Duration.ONE_SECOND).until(() -> runner.runCounter.get() == 2);
+    await().atMost(Duration.ONE_SECOND).until(() -> runner.runCounter.get() == 1);
   }
 
   @Test


### PR DESCRIPTION
The model updating is just an internal state update because there can’t be any observers yet, and the effects are still posted to the effect work runner, so there shouldn’t be any behavior changes because of this modification.