### PR TITLE
Improve error message for events received post-dispose

### DIFF
--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusLoop.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusLoop.java
@@ -140,7 +140,10 @@ public class MobiusLoop<M, E, F> implements Disposable {
   public void dispatchEvent(E event) {
     if (disposed)
       throw new IllegalStateException(
-          "This loop has already been disposed. You cannot dispatch events after disposal");
+          String.format(
+              "This loop has already been disposed. You cannot dispatch events after "
+                  + "disposal - event received: %s=%s, currentModel: %s",
+              event.getClass().getName(), event, mostRecentModel));
     eventDispatcher.accept(checkNotNull(event));
   }
 


### PR DESCRIPTION
Without more details, it's hard to know which loop of many received an event
after disposal. By including the event and model in the exception string,
there should be some more clues to use for debugging.