### PR TITLE
Ensure MobiusLoopController behaves correctly for loops with init

### DIFF
--- a/mobius-core/src/main/java/com/spotify/mobius/ControllerStateRunning.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/ControllerStateRunning.java
@@ -21,6 +21,7 @@ package com.spotify.mobius;
 
 import com.spotify.mobius.functions.Consumer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 class ControllerStateRunning<M, E, F> extends ControllerStateBase<M, E> {
   @Nonnull private final ControllerActions<M, E> actions;
@@ -33,14 +34,19 @@ class ControllerStateRunning<M, E, F> extends ControllerStateBase<M, E> {
       Connection<M> renderer,
       MobiusLoop.Factory<M, E, F> loopFactory,
       M modelToStartFrom,
-      Init<M, F> init) {
-
-    First<M, F> first = init.init(modelToStartFrom);
+      @Nullable Init<M, F> init) {
 
     this.actions = actions;
     this.renderer = renderer;
-    this.loop = loopFactory.startFrom(first.model(), first.effects());
-    this.startModel = first.model();
+
+    if (init != null) {
+      First<M, F> first = init.init(modelToStartFrom);
+      this.loop = loopFactory.startFrom(first.model(), first.effects());
+      this.startModel = first.model();
+    } else {
+      this.loop = loopFactory.startFrom(modelToStartFrom);
+      this.startModel = modelToStartFrom;
+    }
   }
 
   void start() {

--- a/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
@@ -138,8 +138,7 @@ public final class Mobius {
    */
   public static <M, E, F> MobiusLoop.Controller<M, E> controller(
       MobiusLoop.Factory<M, E, F> loopFactory, M defaultModel) {
-    return new MobiusLoopController<>(
-        loopFactory, defaultModel, model -> First.<M, F>first(model), WorkRunners.immediate());
+    return new MobiusLoopController<>(loopFactory, defaultModel, null, WorkRunners.immediate());
   }
 
   /**
@@ -165,8 +164,7 @@ public final class Mobius {
    */
   public static <M, E, F> MobiusLoop.Controller<M, E> controller(
       MobiusLoop.Factory<M, E, F> loopFactory, M defaultModel, WorkRunner modelRunner) {
-    return new MobiusLoopController<>(
-        loopFactory, defaultModel, model -> First.<M, F>first(model), modelRunner);
+    return new MobiusLoopController<>(loopFactory, defaultModel, null, modelRunner);
   }
 
   /**

--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusLoopController.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusLoopController.java
@@ -31,7 +31,7 @@ class MobiusLoopController<M, E, F>
 
   private final MobiusLoop.Factory<M, E, F> loopFactory;
   private final M defaultModel;
-  private final Init<M, F> init;
+  @Nullable private final Init<M, F> init;
   private final WorkRunner mainThreadRunner;
 
   private ControllerStateBase<M, E> currentState;
@@ -39,12 +39,12 @@ class MobiusLoopController<M, E, F>
   MobiusLoopController(
       MobiusLoop.Factory<M, E, F> loopFactory,
       M defaultModel,
-      Init<M, F> init,
+      @Nullable Init<M, F> init,
       WorkRunner mainThreadRunner) {
 
     this.loopFactory = checkNotNull(loopFactory);
     this.defaultModel = checkNotNull(defaultModel);
-    this.init = checkNotNull(init);
+    this.init = init;
     this.mainThreadRunner = checkNotNull(mainThreadRunner);
     goToStateInit(defaultModel);
   }


### PR DESCRIPTION
Without this fix, there would be no way to start a loop that had been configured with an Init, since you'd
always run into an IllegalArgumentException exception.