### PR TITLE
Fix MobiusAndroidController MobiusController creation

### DIFF
--- a/mobius-android/src/main/java/com/spotify/mobius/android/MobiusAndroid.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MobiusAndroid.java
@@ -19,7 +19,6 @@
  */
 package com.spotify.mobius.android;
 
-import com.spotify.mobius.First;
 import com.spotify.mobius.Init;
 import com.spotify.mobius.Mobius;
 import com.spotify.mobius.MobiusLoop;
@@ -32,8 +31,7 @@ public final class MobiusAndroid {
 
   public static <M, E, F> MobiusLoop.Controller<M, E> controller(
       MobiusLoop.Factory<M, E, F> loopFactory, M defaultModel) {
-    return Mobius.<M, E, F>controller(
-        loopFactory, defaultModel, First::first, MainThreadWorkRunner.create());
+    return Mobius.<M, E, F>controller(loopFactory, defaultModel, MainThreadWorkRunner.create());
   }
 
   public static <M, E, F> MobiusLoop.Controller<M, E> controller(


### PR DESCRIPTION
It needs to not add an init if none was requested.