### PR TITLE
Fix event source setup behaviour

### DIFF
--- a/mobius-core/src/main/java/com/spotify/mobius/QueuingConnection.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/QueuingConnection.java
@@ -1,0 +1,75 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius;
+
+import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides a connection that queues up messages until a delegate to consume them is available.
+ * Useful for setting up circular dependencies safely. All methods are synchronized for ease of
+ * implementation.
+ */
+class QueuingConnection<I> implements Connection<I> {
+
+  private final List<I> queue = new ArrayList<>();
+
+  private Connection<I> delegate;
+  private boolean disposed = false;
+
+  synchronized void setDelegate(Connection<I> delegate) {
+    if (this.delegate != null) {
+      throw new IllegalStateException("Attempt at setting delegate twice");
+    }
+
+    this.delegate = checkNotNull(delegate);
+
+    if (disposed) {
+      return;
+    }
+
+    for (I item : queue) {
+      delegate.accept(item);
+    }
+
+    queue.clear();
+  }
+
+  @Override
+  public synchronized void accept(I value) {
+    if (delegate != null) {
+      delegate.accept(value);
+      return;
+    }
+
+    queue.add(value);
+  }
+
+  @Override
+  public synchronized void dispose() {
+    disposed = true;
+
+    if (delegate != null) {
+      delegate.dispose();
+    }
+  }
+}

--- a/mobius-core/src/test/java/com/spotify/mobius/QueuingConnectionTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/QueuingConnectionTest.java
@@ -1,0 +1,98 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import com.spotify.mobius.test.RecordingConnection;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueuingConnectionTest {
+
+  private QueuingConnection<String> connection;
+  private RecordingConnection<String> delegate;
+
+  @Before
+  public void setUp() throws Exception {
+    delegate = new RecordingConnection<>();
+
+    connection = new QueuingConnection<>();
+  }
+
+  @Test
+  public void shouldForwardAcceptToDelegateWhenAvailable() throws Exception {
+    connection.setDelegate(delegate);
+
+    connection.accept("hey there");
+    connection.accept("hi!");
+
+    delegate.assertValues("hey there", "hi!");
+  }
+
+  @Test
+  public void shouldQueueAcceptBeforeDelegateAvailable() throws Exception {
+
+    connection.accept("hey there");
+    connection.accept("hi!");
+
+    // nothing yet
+    delegate.assertValues();
+
+    // provide delegate and expect the values to show up
+    connection.setDelegate(delegate);
+
+    delegate.assertValues("hey there", "hi!");
+  }
+
+  @Test
+  public void shouldForwardDisposeToDelegate() throws Exception {
+    connection.setDelegate(delegate);
+    connection.dispose();
+
+    assertThat(delegate.disposed, is(true));
+  }
+
+  @Test
+  public void shouldSupportDisposeWithoutDelegate() throws Exception {
+    connection.dispose();
+  }
+
+  @Test
+  public void shouldNotForwardQueuedValuesAfterDispose() throws Exception {
+    connection.accept("don't want to see this");
+
+    connection.dispose();
+
+    connection.setDelegate(delegate);
+
+    delegate.assertValues();
+  }
+
+  @Test
+  public void shouldNotAllowDuplicateDelegates() throws Exception {
+    connection.setDelegate(delegate);
+
+    assertThatThrownBy(() -> connection.setDelegate(new RecordingConnection<>()))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/mobius-test/src/main/java/com/spotify/mobius/test/RecordingConnection.java
+++ b/mobius-test/src/main/java/com/spotify/mobius/test/RecordingConnection.java
@@ -1,0 +1,31 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.test;
+
+import com.spotify.mobius.Connection;
+
+public class RecordingConnection<V> extends RecordingConsumer<V> implements Connection<V> {
+  public volatile boolean disposed = false;
+
+  @Override
+  public void dispose() {
+    disposed = true;
+  }
+}


### PR DESCRIPTION
Without this, an event source that emits an event immediately would lead to an
exception being logged and the event ignored.