### PR TITLE
Changed viewmodel constructor to protected to accommodate extensibility

### DIFF
--- a/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopViewModel.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopViewModel.java
@@ -62,7 +62,7 @@ public class MobiusLoopViewModel<M, E, F, V> extends ViewModel {
   private final MobiusLoop<M, E, F> loop;
   private final M startModel;
 
-  private MobiusLoopViewModel(
+  protected MobiusLoopViewModel(
       @Nonnull Function<Consumer<V>, Factory<M, E, F>> loopFactoryProvider,
       @Nonnull M modelToStartFrom,
       @Nonnull Init<M, F> init,


### PR DESCRIPTION
The view model is likely to require extending it to be used, changing the constructor to allow this to be done.