### PR TITLE
improve error logging for failed event processing

### DIFF
--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusLoop.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusLoop.java
@@ -139,6 +139,13 @@ public class MobiusLoop<M, E, F> implements Disposable {
     this.eventSourceModelConsumer.setDelegate(eventSource.connect(eventConsumer));
   }
 
+  /**
+   * Dispatch an event to this loop for processing.
+   *
+   * @param event the event to process
+   * @throws IllegalStateException if the loop has been disposed, or if there is an error processing
+   *     the event.
+   */
   public void dispatchEvent(E event) {
     if (disposed)
       throw new IllegalStateException(
@@ -146,7 +153,12 @@ public class MobiusLoop<M, E, F> implements Disposable {
               "This loop has already been disposed. You cannot dispatch events after "
                   + "disposal - event received: %s=%s, currentModel: %s",
               event.getClass().getName(), event, mostRecentModel));
-    eventDispatcher.accept(checkNotNull(event));
+
+    try {
+      eventDispatcher.accept(checkNotNull(event));
+    } catch (RuntimeException e) {
+      throw new IllegalStateException("Exception processing event: " + event, e);
+    }
   }
 
   @Nullable

--- a/mobius-core/src/test/java/com/spotify/mobius/MobiusLoopErrorReporting.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/MobiusLoopErrorReporting.java
@@ -1,0 +1,61 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.spotify.mobius.runners.ExecutorServiceWorkRunner;
+import com.spotify.mobius.runners.WorkRunner;
+import com.spotify.mobius.test.RecordingModelObserver;
+import com.spotify.mobius.testdomain.TestEvent;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.Test;
+
+public class MobiusLoopErrorReporting extends MobiusLoopTest {
+
+  @Test
+  public void shouldIncludeEventInExceptionWhenDispatchFails() throws Exception {
+    // given a loop
+    observer = new RecordingModelObserver<>();
+
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    WorkRunner eventRunner = new ExecutorServiceWorkRunner(executorService);
+
+    mobiusLoop =
+        MobiusLoop.create(
+            update,
+            startModel,
+            startEffects,
+            effectHandler,
+            eventSource,
+            eventRunner,
+            immediateRunner);
+
+    // whose event workrunner has been disposed.
+    eventRunner.dispose();
+
+    // when an event is dispatched,
+    // then the exception contains a description of the event.
+    assertThatThrownBy(
+            () -> mobiusLoop.dispatchEvent(new TestEvent("print me in the exception message")))
+        .hasMessageContaining("print me in the exception message");
+  }
+}


### PR DESCRIPTION
Logs the event that failed to process - this will help troubleshooting,
as the stack traces often don't provide any ideas about where the error
comes from.