### PR TITLE
add a QueueingEventSubject

### DIFF
--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/QueueingEventSubject.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/QueueingEventSubject.java
@@ -1,0 +1,118 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras;
+
+import com.spotify.mobius.EventSource;
+import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.functions.Consumer;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import javax.annotation.Nonnull;
+
+/**
+ * An EventSource that can also consume events. If it has a subscriber, events will be immediately
+ * forwarded to that subscriber. If it doesn't have a subscriber, it will queue up events (up to the
+ * maximum capacity specified in the constructor), and forward all queued events to the next
+ * subscriber. Only a single subscription at a time is permitted.
+ */
+public final class QueueingEventSubject<E> implements EventSource<E>, Consumer<E> {
+
+  private enum State {
+    NO_SUBSCRIBER,
+    SUBSCRIBED
+  }
+
+  private final BlockingQueue<E> queue;
+
+  // these two fields are only read and written within synchronized sections
+  private State state;
+  private Consumer<E> subscriber;
+
+  public QueueingEventSubject(int capacity) {
+    queue = new ArrayBlockingQueue<>(capacity);
+    state = State.NO_SUBSCRIBER;
+  }
+
+  @Nonnull
+  @Override
+  public Disposable subscribe(Consumer<E> eventConsumer) {
+    List<E> queued = new LinkedList<>();
+
+    // avoid calling the consumer from the synchronized section
+    synchronized (this) {
+      if (state == State.SUBSCRIBED) {
+        throw new IllegalStateException(
+            "Only a single subscription is supported, previous subscriber is: " + subscriber);
+      }
+
+      state = State.SUBSCRIBED;
+      subscriber = eventConsumer;
+      queue.drainTo(queued);
+    }
+
+    for (E event : queued) {
+      eventConsumer.accept(event);
+    }
+
+    return new Unsubscriber();
+  }
+
+  @Override
+  public void accept(E value) {
+    Consumer<E> consumerToInvoke = null;
+
+    // avoid calling the consumer from the synchronized section
+    synchronized (this) {
+      switch (state) {
+        case NO_SUBSCRIBER:
+          queue.add(value);
+          break;
+        case SUBSCRIBED:
+          consumerToInvoke = subscriber;
+          break;
+      }
+    }
+
+    if (consumerToInvoke != null) {
+      consumerToInvoke.accept(value);
+    }
+  }
+
+  private synchronized void unsubscribe() {
+    state = State.NO_SUBSCRIBER;
+    subscriber = null;
+  }
+
+  private class Unsubscriber implements Disposable {
+    private boolean disposed = false;
+
+    @Override
+    public synchronized void dispose() {
+      if (disposed) {
+        return;
+      }
+
+      disposed = true;
+      unsubscribe();
+    }
+  }
+}

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/QueueingEventSubjectTest.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/QueueingEventSubjectTest.java
@@ -1,0 +1,131 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.test.RecordingConsumer;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueueingEventSubjectTest {
+  private QueueingEventSubject<String> eventSubject;
+  private RecordingConsumer<String> receiver;
+
+  @Before
+  public void setUp() throws Exception {
+    eventSubject = new QueueingEventSubject<>(3);
+    receiver = new RecordingConsumer<>();
+  }
+
+  @Test
+  public void shouldForwardEventsWhenSubscribed() throws Exception {
+    eventSubject.subscribe(receiver);
+
+    eventSubject.accept("hey");
+
+    receiver.assertValues("hey");
+  }
+
+  @Test
+  public void shouldQueueEventsWhenNotSubscribed() throws Exception {
+    eventSubject.accept("hi");
+    eventSubject.accept("ho");
+    eventSubject.accept("to the mines we go");
+
+    eventSubject.subscribe(receiver);
+
+    receiver.assertValues("hi", "ho", "to the mines we go");
+  }
+
+  @Test
+  public void shouldStopSendingEventsWhenSubscriptionDisposed() throws Exception {
+    final Disposable subscription = eventSubject.subscribe(receiver);
+
+    eventSubject.accept("a");
+    eventSubject.accept("b");
+
+    subscription.dispose();
+
+    eventSubject.accept("don't want to see this");
+
+    receiver.assertValues("a", "b");
+  }
+
+  @Test
+  public void shouldOnlySupportASingleSubscriber() throws Exception {
+    eventSubject.subscribe(receiver);
+
+    assertThatThrownBy(() -> eventSubject.subscribe(new RecordingConsumer<>()))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void shouldSupportUnsubscribeAndResubscribe() throws Exception {
+    eventSubject.accept("a");
+
+    Disposable subscription = eventSubject.subscribe(receiver);
+
+    eventSubject.accept("b");
+
+    subscription.dispose();
+
+    eventSubject.accept("c");
+
+    eventSubject.subscribe(receiver);
+
+    receiver.assertValues("a", "b", "c");
+  }
+
+  @Test
+  public void shouldThrowWhenCapacityExceeded() throws Exception {
+    eventSubject.accept("a");
+    eventSubject.accept("b");
+    eventSubject.accept("c");
+
+    assertThatThrownBy(() -> eventSubject.accept("noo, too many things"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void unsubscribeShouldBeIdempotent() throws Exception {
+    // given a subscription that has been disposed
+    Disposable subscription1 = eventSubject.subscribe(receiver);
+
+    subscription1.dispose();
+
+    // and a new subscription has been created
+    Disposable subscription2 = eventSubject.subscribe(receiver);
+
+    // when the first subscription is disposed again
+    subscription1.dispose();
+
+    // then the second subscription is not disposed
+    eventSubject.accept("a");
+
+    // and disposing the second subscription works
+    subscription2.dispose();
+
+    eventSubject.accept("b");
+
+    receiver.assertValues("a");
+  }
+}


### PR DESCRIPTION
This is intended to be used when one wants to send events to a loop, but the
creation of the events is asynchronous with or otherwise hard to relate to
startup of the loop. For instance, when using onActivityResult in Android.