### PR TITLE
Added a check that stops events being forwarded after the view model is cleared

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,8 @@ ext {
             'jsr305'           : '3.0.2',
             'hamcrestLibrary'  : '1.3',
             'mockito'          : '1.10.19',
-            'androidxLifecycle' : '2.2.0'
+            'androidxLifecycle' : '2.2.0',
+            'androidXCoreTesting' : '2.1.0'
     ]
 }
 

--- a/mobius-android/build.gradle
+++ b/mobius-android/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 
     testImplementation project(':mobius-test')
     testImplementation "junit:junit:${versions.junit}"
+    testImplementation "androidx.arch.core:core-testing:${versions.androidXCoreTesting}"
     testImplementation "androidx.lifecycle:lifecycle-runtime:${versions.androidxLifecycle}"
     testImplementation "org.assertj:assertj-core:${versions.assertjcore}"
     testImplementation "org.hamcrest:hamcrest-library:${versions.hamcrestLibrary}"

--- a/mobius-android/src/main/java/com/spotify/mobius/android/LiveQueue.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/LiveQueue.java
@@ -50,7 +50,7 @@ public interface LiveQueue<T> {
    * substitutes null for the optional observer. See linked method doc for full info.
    */
   void setObserver(
-      @Nonnull LifecycleOwner lifecycleOwner, @Nonnull Observer<? super T> liveEffectsObserver);
+      @Nonnull LifecycleOwner lifecycleOwner, @Nonnull Observer<T> liveEffectsObserver);
 
   /**
    * The <code>LiveQueue</code> supports only a single observer, so calling this method will
@@ -71,8 +71,8 @@ public interface LiveQueue<T> {
    */
   void setObserver(
       @Nonnull LifecycleOwner lifecycleOwner,
-      @Nonnull Observer<? super T> liveEffectsObserver,
-      @Nullable Observer<Iterable<? super T>> pausedEffectsObserver);
+      @Nonnull Observer<T> liveEffectsObserver,
+      @Nullable Observer<Iterable<T>> pausedEffectsObserver);
 
   /**
    * Removes the current observer and clears any queued effects.<br>

--- a/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopViewModel.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopViewModel.java
@@ -96,7 +96,7 @@ public class MobiusLoopViewModel<M, E, F, V> extends ViewModel {
    * @param <F> the effect type
    * @param <V> the view effect type
    */
-  public static <M, E, F, V> MobiusLoopViewModel create(
+  public static <M, E, F, V> MobiusLoopViewModel<M, E, F, V> create(
       @Nonnull Function<Consumer<V>, Factory<M, E, F>> loopFactoryProvider,
       @Nonnull M modelToStartFrom,
       @Nonnull Init<M, F> init) {

--- a/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopViewModel.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopViewModel.java
@@ -30,6 +30,7 @@ import com.spotify.mobius.android.runners.MainThreadWorkRunner;
 import com.spotify.mobius.functions.Consumer;
 import com.spotify.mobius.functions.Function;
 import com.spotify.mobius.runners.WorkRunner;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
 
 /**
@@ -67,6 +68,7 @@ public class MobiusLoopViewModel<M, E, F, V> extends ViewModel {
   private final MutableLiveQueue<V> viewEffectQueue;
   private final MobiusLoop<M, E, F> loop;
   private final M startModel;
+  private final AtomicBoolean loopActive = new AtomicBoolean(true);
 
   protected MobiusLoopViewModel(
       @Nonnull Function<Consumer<V>, Factory<M, E, F>> loopFactoryProvider,
@@ -144,12 +146,15 @@ public class MobiusLoopViewModel<M, E, F, V> extends ViewModel {
   }
 
   public final void dispatchEvent(@Nonnull E event) {
-    loop.dispatchEvent(event);
+    if (loopActive.get()) {
+      loop.dispatchEvent(event);
+    }
   }
 
   @Override
   protected final void onCleared() {
     super.onCleared();
+    loopActive.set(false);
     loop.dispose();
   }
 

--- a/mobius-android/src/main/java/com/spotify/mobius/android/MutableLiveQueue.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MutableLiveQueue.java
@@ -52,8 +52,8 @@ final class MutableLiveQueue<T> implements LiveQueue<T> {
   private final Object lock = new Object();
   private final WorkRunner effectsWorkRunner;
   private final BlockingQueue<T> pausedEffectsQueue;
-  @Nullable private Observer<? super T> liveObserver = null;
-  @Nullable private Observer<Iterable<? super T>> pausedObserver = null;
+  @Nullable private Observer<T> liveObserver = null;
+  @Nullable private Observer<Iterable<T>> pausedObserver = null;
   private boolean lifecycleOwnerIsPaused = true;
 
   MutableLiveQueue(WorkRunner effectsWorkRunner, int capacity) {
@@ -72,16 +72,15 @@ final class MutableLiveQueue<T> implements LiveQueue<T> {
   }
 
   @Override
-  public void setObserver(
-      @Nonnull LifecycleOwner owner, @Nonnull Observer<? super T> liveEffectsObserver) {
+  public void setObserver(@Nonnull LifecycleOwner owner, @Nonnull Observer<T> liveEffectsObserver) {
     setObserver(owner, liveEffectsObserver, null);
   }
 
   @Override
   public void setObserver(
       @Nonnull LifecycleOwner lifecycleOwner,
-      @Nonnull Observer<? super T> liveObserver,
-      @Nullable Observer<Iterable<? super T>> pausedObserver) {
+      @Nonnull Observer<T> liveObserver,
+      @Nullable Observer<Iterable<T>> pausedObserver) {
     if (lifecycleOwner.getLifecycle().getCurrentState() == DESTROYED) {
       return; // ignore
     }

--- a/mobius-android/src/test/java/com/spotify/mobius/android/FakeLifecycleOwner.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/FakeLifecycleOwner.java
@@ -30,8 +30,11 @@ import org.mockito.Mockito;
 public class FakeLifecycleOwner implements LifecycleOwner {
   private final LifecycleRegistry lifecycle;
 
+  @SuppressWarnings("FieldCanBeLocal")
+  private final LifecycleOwner owner;
+
   FakeLifecycleOwner() {
-    LifecycleOwner owner = mock(LifecycleOwner.class);
+    owner = mock(LifecycleOwner.class);
     lifecycle = new LifecycleRegistry(owner);
     Mockito.when(owner.getLifecycle()).thenReturn(lifecycle);
   }

--- a/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTest.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTest.java
@@ -129,7 +129,7 @@ public class MobiusLoopViewModelTest {
 
   @Test
   public void
-      testViewModelSendsViewEffectsToBackgroundObseerveWhenLifecycleWasPausedThenIsResumed() {
+      testViewModelSendsViewEffectsToBackgroundObserverWhenLifecycleWasPausedThenIsResumed() {
     fakeLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
     fakeLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
     testViewEffectHandler.viewEffectConsumer.accept(new TestViewEffect("view effect 1"));

--- a/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTest.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTest.java
@@ -1,0 +1,156 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.android;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.Lifecycle;
+import com.spotify.mobius.First;
+import com.spotify.mobius.Mobius;
+import com.spotify.mobius.Next;
+import com.spotify.mobius.Update;
+import com.spotify.mobius.android.MobiusLoopViewModelTestUtilClasses.TestEffect;
+import com.spotify.mobius.android.MobiusLoopViewModelTestUtilClasses.TestEvent;
+import com.spotify.mobius.android.MobiusLoopViewModelTestUtilClasses.TestModel;
+import com.spotify.mobius.android.MobiusLoopViewModelTestUtilClasses.TestViewEffect;
+import com.spotify.mobius.android.MobiusLoopViewModelTestUtilClasses.TestViewEffectHandler;
+import com.spotify.mobius.functions.Consumer;
+import com.spotify.mobius.runners.ImmediateWorkRunner;
+import java.util.LinkedList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MobiusLoopViewModelTest {
+
+  private final List<TestEvent> recordedEvents = new LinkedList<>();
+  private final List<TestModel> recordedModels = new LinkedList<>();
+  private final Update<TestModel, TestEvent, TestEffect> updateFunction =
+      (model, event) -> {
+        recordedModels.add(model);
+        recordedEvents.add(event);
+        return Next.noChange();
+      };
+  @Rule public InstantTaskExecutorRule rule = new InstantTaskExecutorRule();
+  private MobiusLoopViewModel<TestModel, TestEvent, TestEffect, TestViewEffect> underTest;
+  private TestViewEffectHandler<TestEvent, TestEffect, TestViewEffect> testViewEffectHandler;
+
+  private FakeLifecycleOwner fakeLifecycle;
+  private RecordingObserver<TestModel> recordingModelObserver = new RecordingObserver<>();
+  private RecordingObserver<TestViewEffect> recordingForegroundViewEffectObserver =
+      new RecordingObserver<>();
+  private RecordingObserver<Iterable<TestViewEffect>> recordingBackgroundEffectObserver =
+      new RecordingObserver<>();
+
+  @Before
+  public void setUp() {
+    fakeLifecycle = new FakeLifecycleOwner();
+    recordedEvents.clear();
+    recordedModels.clear();
+    testViewEffectHandler = null;
+    recordingModelObserver.clearValues();
+    recordingForegroundViewEffectObserver.clearValues();
+    recordingBackgroundEffectObserver.clearValues();
+    //noinspection Convert2MethodRef
+    underTest =
+        new MobiusLoopViewModel<>(
+            (Consumer<TestViewEffect> consumer) -> {
+              testViewEffectHandler = new TestViewEffectHandler<>(consumer);
+              return Mobius.loop(updateFunction, testViewEffectHandler)
+                  .eventRunner(ImmediateWorkRunner::new)
+                  .effectRunner(ImmediateWorkRunner::new);
+            },
+            new TestModel("initial model"),
+            (TestModel model) -> First.first(model),
+            new ImmediateWorkRunner(),
+            100);
+    underTest.getModels().observe(fakeLifecycle, recordingModelObserver);
+    underTest
+        .getViewEffects()
+        .setObserver(
+            fakeLifecycle,
+            recordingForegroundViewEffectObserver,
+            recordingBackgroundEffectObserver);
+  }
+
+  @Test
+  public void testViewModelgetModelAtStartIsInitialModel() {
+    fakeLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+
+    assertThat(underTest.getModel().name, equalTo("initial model"));
+  }
+
+  @Test
+  public void testViewModelSendsEventAndModelIntoLoop() {
+    fakeLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    testViewEffectHandler.sendEvent(new TestEvent("an initial event"));
+
+    assertThat(recordedModels.size(), equalTo(1));
+    assertThat(recordedModels.get(0).name, equalTo("initial model"));
+    assertThat(recordedEvents.size(), equalTo(1));
+    assertThat(recordedEvents.get(0).name, equalTo("an initial event"));
+  }
+
+  @Test
+  public void testViewModelSendsEffectsIntoLoop() {
+    fakeLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    underTest.dispatchEvent(new TestEvent("testable"));
+    assertThat(recordedEvents.size(), equalTo(1));
+    assertThat(recordedEvents.get(0).name, equalTo("testable"));
+  }
+
+  @Test
+  public void testViewModelDoesNotSendViewEffectsIfLifecycleIsPaused() {
+    fakeLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
+    testViewEffectHandler.viewEffectConsumer.accept(new TestViewEffect("view effect 1"));
+    assertThat(recordingForegroundViewEffectObserver.valueCount(), equalTo(0));
+    assertThat(recordingBackgroundEffectObserver.valueCount(), equalTo(0));
+  }
+
+  @Test
+  public void
+      testViewModelSendsViewEffectsToBackgroundObseerveWhenLifecycleWasPausedThenIsResumed() {
+    fakeLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    fakeLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
+    testViewEffectHandler.viewEffectConsumer.accept(new TestViewEffect("view effect 1"));
+    assertThat(recordingBackgroundEffectObserver.valueCount(), equalTo(0));
+    fakeLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    assertThat(recordingBackgroundEffectObserver.valueCount(), equalTo(1));
+  }
+
+  @Test
+  public void testViewModelSendsViewEffectsToForegroundObserverWhenLifecycleIsResumed() {
+    fakeLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    testViewEffectHandler.viewEffectConsumer.accept(new TestViewEffect("view effect 1"));
+    assertThat(recordingForegroundViewEffectObserver.valueCount(), equalTo(1));
+    assertThat(recordingBackgroundEffectObserver.valueCount(), equalTo(0));
+  }
+
+  @Test
+  public void testViewModelDoesNotTryToForwardEventsIntoLoopAfterCleared() {
+    fakeLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    underTest.onCleared();
+    underTest.dispatchEvent(new TestEvent("don't record me"));
+    assertThat(recordedEvents.size(), equalTo(0));
+  }
+}

--- a/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTestUtilClasses.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTestUtilClasses.java
@@ -1,0 +1,76 @@
+package com.spotify.mobius.android;
+
+import com.spotify.mobius.Connectable;
+import com.spotify.mobius.Connection;
+import com.spotify.mobius.ConnectionLimitExceededException;
+import com.spotify.mobius.functions.Consumer;
+import javax.annotation.Nonnull;
+
+public class MobiusLoopViewModelTestUtilClasses {
+  static class TestEvent {
+    final String name;
+
+    TestEvent(String name) {
+      this.name = name;
+    }
+  }
+
+  static class TestEffect {
+    final String name;
+
+    TestEffect(String name) {
+      this.name = name;
+    }
+  }
+
+  static class TestModel {
+    final String name;
+
+    TestModel(String name) {
+      this.name = name;
+    }
+  }
+
+  static class TestViewEffect {
+    final String name;
+
+    TestViewEffect(String name) {
+      this.name = name;
+    }
+  }
+
+  static class TestViewEffectHandler<E, F, V> implements Connectable<F, E> {
+    final Consumer<V> viewEffectConsumer;
+    private volatile Consumer<E> eventConsumer = null;
+
+    TestViewEffectHandler(Consumer<V> viewEffectConsumer) {
+      this.viewEffectConsumer = viewEffectConsumer;
+    }
+
+    public void sendEvent(E event) {
+      eventConsumer.accept(event);
+    }
+
+    @Nonnull
+    @Override
+    public Connection<F> connect(Consumer<E> output) throws ConnectionLimitExceededException {
+      if (eventConsumer != null) {
+        throw new ConnectionLimitExceededException();
+      }
+
+      eventConsumer = output;
+
+      return new Connection<F>() {
+        @Override
+        public void accept(F value) {
+          // do nothing
+        }
+
+        @Override
+        public void dispose() {
+          // do nothing
+        }
+      };
+    }
+  }
+}

--- a/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTestUtilClasses.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTestUtilClasses.java
@@ -1,3 +1,22 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.mobius.android;
 
 import com.spotify.mobius.Connectable;
@@ -7,6 +26,8 @@ import com.spotify.mobius.functions.Consumer;
 import javax.annotation.Nonnull;
 
 public class MobiusLoopViewModelTestUtilClasses {
+  private MobiusLoopViewModelTestUtilClasses() {}
+
   static class TestEvent {
     final String name;
 

--- a/mobius-android/src/test/java/com/spotify/mobius/android/MutableLiveQueueTest.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/MutableLiveQueueTest.java
@@ -20,8 +20,8 @@
 package com.spotify.mobius.android;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 import androidx.lifecycle.Lifecycle;
 import com.spotify.mobius.runners.WorkRunners;
@@ -39,7 +39,7 @@ public class MutableLiveQueueTest {
   private FakeLifecycleOwner fakeLifecycleOwner1;
   private FakeLifecycleOwner fakeLifecycleOwner2;
   private RecordingObserver<String> liveObserver;
-  private RecordingObserver<Iterable<? super String>> pausedObserver;
+  private RecordingObserver<Iterable<String>> pausedObserver;
 
   @Before
   public void setup() {

--- a/mobius-core/src/test/java/com/spotify/mobius/MobiusLoopTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/MobiusLoopTest.java
@@ -134,11 +134,11 @@ public class MobiusLoopTest {
     mobiusLoop.observe(observer);
   }
 
-  public static class FakeEffectHandler implements Connectable<TestEffect, TestEvent> {
+  static class FakeEffectHandler implements Connectable<TestEffect, TestEvent> {
 
     private volatile Consumer<TestEvent> eventConsumer = null;
 
-    public void emitEvent(TestEvent event) {
+    void emitEvent(TestEvent event) {
       // throws NPE if not connected; that's OK
       eventConsumer.accept(event);
     }

--- a/mobius-core/src/test/java/com/spotify/mobius/MobiusLoopTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/MobiusLoopTest.java
@@ -134,11 +134,11 @@ public class MobiusLoopTest {
     mobiusLoop.observe(observer);
   }
 
-  static class FakeEffectHandler implements Connectable<TestEffect, TestEvent> {
+  public static class FakeEffectHandler implements Connectable<TestEffect, TestEvent> {
 
     private volatile Consumer<TestEvent> eventConsumer = null;
 
-    void emitEvent(TestEvent event) {
+    public void emitEvent(TestEvent event) {
       // throws NPE if not connected; that's OK
       eventConsumer.accept(event);
     }


### PR DESCRIPTION
Updated PR:

Added tests, and modified the types of listeners expected by LiveQueue.