### PR TITLE
Ensure RxJava-related errors don't throw NPEs

### DIFF
--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxConnectables.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxConnectables.java
@@ -66,7 +66,7 @@ public final class RxConnectables {
                     new io.reactivex.functions.Consumer<Throwable>() {
                       @Override
                       public void accept(Throwable throwable) throws Exception {
-                        RxJavaPlugins.getErrorHandler().accept(throwable);
+                        RxJavaPlugins.onError(throwable);
                       }
                     },
                     new Action() {

--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
@@ -422,7 +422,7 @@ public final class RxMobius {
     /**
      * Optionally set a shared error handler in case a handler throws an uncaught exception.
      *
-     * <p>The default is to use {@link RxJavaPlugins#getErrorHandler()}. Note that any exception
+     * <p>The default is to use {@link RxJavaPlugins#onError(Throwable)}. Note that any exception
      * thrown by a handler is a fatal error and this method doesn't enable safe error handling, only
      * configurable crash reporting.
      *


### PR DESCRIPTION
The getErrorHandler() method can return null; the safe way is to use the
onError(Throwable) hook.