### PR TITLE
Made rx2 RxMobiusLoopTest more robust

### DIFF
--- a/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxMobiusLoopTest.java
+++ b/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxMobiusLoopTest.java
@@ -41,11 +41,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class RxMobiusLoopTest {
-  private RecordingConnection<Boolean> connection = new RecordingConnection<>();
+  private RecordingConnection<Boolean> connection;
   private MobiusLoop.Factory<String, Integer, Boolean> factory;
 
   @Before
   public void setUp() throws Exception {
+    connection = new RecordingConnection<>();
     factory =
         Mobius.loop(
             new Update<String, Integer, Boolean>() {


### PR DESCRIPTION
Moved the initialization of the rx2 RxMobiusLoopTest member connection
to setUp, making the test more predictable.