### PR TITLE
Ensure that RxMobius.startFrom supports Init

### DIFF
--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusLoop.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusLoop.java
@@ -322,6 +322,8 @@ public class MobiusLoop<M, E, F> implements Loop<M, E, F> {
      * @param startModel the model that the loop should start from
      * @param startEffects the effects that the loop should start with
      * @return the started {@link MobiusLoop}
+     * @throws IllegalStateException if the loop has been configured with an {@link Init}, since
+     *     that would conflict with the initial effects passed in.
      */
     MobiusLoop<M, E, F> startFrom(M startModel, Set<F> startEffects);
   }

--- a/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobius.java
+++ b/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobius.java
@@ -26,7 +26,6 @@ import com.spotify.mobius.Mobius;
 import com.spotify.mobius.MobiusLoop;
 import com.spotify.mobius.Update;
 import com.spotify.mobius.functions.Function;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +58,7 @@ public final class RxMobius {
    */
   public static <M, E, F> Observable.Transformer<E, M> loopFrom(
       final MobiusLoop.Factory<M, E, F> loopFactory, final M startModel) {
-    return loopFrom(loopFactory, startModel, Collections.emptySet());
+    return new RxMobiusLoop<>(loopFactory, startModel, null);
   }
 
   /**

--- a/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobiusLoop.java
+++ b/mobius-rx/src/main/java/com/spotify/mobius/rx/RxMobiusLoop.java
@@ -22,6 +22,7 @@ package com.spotify.mobius.rx;
 import com.spotify.mobius.MobiusLoop;
 import com.spotify.mobius.functions.Consumer;
 import java.util.Set;
+import javax.annotation.Nullable;
 import rx.Emitter;
 import rx.Observable;
 import rx.Observer;
@@ -38,9 +39,9 @@ class RxMobiusLoop<E, M, F> implements Observable.Transformer<E, M> {
 
   private final MobiusLoop.Factory<M, E, F> loopFactory;
   private final M startModel;
-  private final Set<F> startEffects;
+  @Nullable private final Set<F> startEffects;
 
-  RxMobiusLoop(MobiusLoop.Factory<M, E, F> loopFactory, M loopStart, Set<F> effects) {
+  RxMobiusLoop(MobiusLoop.Factory<M, E, F> loopFactory, M loopStart, @Nullable Set<F> effects) {
     this.loopFactory = loopFactory;
     this.startModel = loopStart;
     this.startEffects = effects;
@@ -52,7 +53,13 @@ class RxMobiusLoop<E, M, F> implements Observable.Transformer<E, M> {
         new Action1<Emitter<M>>() {
           @Override
           public void call(final Emitter<M> emitter) {
-            final MobiusLoop<M, E, ?> loop = loopFactory.startFrom(startModel, startEffects);
+            final MobiusLoop<M, E, ?> loop;
+
+            if (startEffects == null) {
+              loop = loopFactory.startFrom(startModel);
+            } else {
+              loop = loopFactory.startFrom(startModel, startEffects);
+            }
 
             loop.observe(
                 new Consumer<M>() {

--- a/mobius-rx/src/test/java/com/spotify/mobius/rx/RxMobiusLoopTest.java
+++ b/mobius-rx/src/test/java/com/spotify/mobius/rx/RxMobiusLoopTest.java
@@ -19,6 +19,7 @@
  */
 package com.spotify.mobius.rx;
 
+import static com.spotify.mobius.Effects.effects;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
@@ -112,5 +113,23 @@ public class RxMobiusLoopTest {
     final AssertableSubscriber<String> observer = Observable.just(10).compose(transformer).test();
 
     observer.assertValues("hi-init");
+  }
+
+  @Test
+  public void shouldThrowIfStartingALoopWithInitAndStartEffects() throws Exception {
+    MobiusLoop.Builder<String, Integer, Boolean> withInit =
+        builder.init(
+            new Init<String, Boolean>() {
+              @Nonnull
+              @Override
+              public First<String, Boolean> init(String model) {
+                return First.first(model + "-init");
+              }
+            });
+
+    Observable.Transformer<Integer, String> transformer =
+        RxMobius.loopFrom(withInit, "hi", effects(true));
+
+    Observable.just(10).compose(transformer).test().assertError(IllegalArgumentException.class);
   }
 }

--- a/mobius-rx/src/test/java/com/spotify/mobius/rx/RxMobiusLoopTest.java
+++ b/mobius-rx/src/test/java/com/spotify/mobius/rx/RxMobiusLoopTest.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableSet;
 import com.spotify.mobius.Connectable;
 import com.spotify.mobius.Connection;
 import com.spotify.mobius.ConnectionLimitExceededException;
+import com.spotify.mobius.First;
+import com.spotify.mobius.Init;
 import com.spotify.mobius.Mobius;
 import com.spotify.mobius.MobiusLoop;
 import com.spotify.mobius.Next;
@@ -43,12 +45,12 @@ import rx.subjects.PublishSubject;
 public class RxMobiusLoopTest {
 
   private RecordingConnection<Boolean> connection;
-  private MobiusLoop.Factory<String, Integer, Boolean> factory;
+  private MobiusLoop.Builder<String, Integer, Boolean> builder;
 
   @Before
   public void setUp() throws Exception {
     connection = new RecordingConnection<>();
-    factory =
+    builder =
         Mobius.loop(
             new Update<String, Integer, Boolean>() {
               @Nonnull
@@ -70,7 +72,7 @@ public class RxMobiusLoopTest {
   @Test
   public void shouldPropagateIncomingErrorsAsUnrecoverable() throws Exception {
     RxMobiusLoop<Integer, String, Boolean> loop =
-        new RxMobiusLoop<>(factory, "", Collections.emptySet());
+        new RxMobiusLoop<>(builder, "", Collections.emptySet());
     PublishSubject<Integer> input = PublishSubject.create();
 
     AssertableSubscriber<String> subscriber = input.compose(loop).test();
@@ -85,11 +87,30 @@ public class RxMobiusLoopTest {
   @Test
   public void startModelAndEffects() {
     RxMobiusLoop<Integer, String, Boolean> loop =
-        new RxMobiusLoop<>(factory, "StartModel", ImmutableSet.of(true, false));
+        new RxMobiusLoop<>(builder, "StartModel", ImmutableSet.of(true, false));
     final AssertableSubscriber<String> subscriber = Observable.just(1).compose(loop).test();
     subscriber.assertValue("StartModel");
     subscriber.assertNoErrors();
     assertEquals(2, connection.valueCount());
     connection.assertValues(true, false);
+  }
+
+  @Test
+  public void shouldSupportStartingALoopWithAnInit() throws Exception {
+    MobiusLoop.Builder<String, Integer, Boolean> withInit =
+        builder.init(
+            new Init<String, Boolean>() {
+              @Nonnull
+              @Override
+              public First<String, Boolean> init(String model) {
+                return First.first(model + "-init");
+              }
+            });
+
+    Observable.Transformer<Integer, String> transformer = RxMobius.loopFrom(withInit, "hi");
+
+    final AssertableSubscriber<String> observer = Observable.just(10).compose(transformer).test();
+
+    observer.assertValues("hi-init");
   }
 }

--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobius.java
@@ -31,7 +31,6 @@ import io.reactivex.functions.Action;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import io.reactivex.plugins.RxJavaPlugins;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -57,7 +56,7 @@ public final class RxMobius {
    */
   public static <M, E, F> ObservableTransformer<E, M> loopFrom(
       final MobiusLoop.Factory<M, E, F> loopFactory, final M startModel) {
-    return loopFrom(loopFactory, startModel, Collections.emptySet());
+    return new RxMobiusLoop<>(loopFactory, startModel, null);
   }
 
   /**

--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobiusLoop.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxMobiusLoop.java
@@ -29,6 +29,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Wraps a MobiusLoop into an observable transformer.
@@ -39,9 +40,10 @@ class RxMobiusLoop<E, M, F> implements ObservableTransformer<E, M> {
 
   private final MobiusLoop.Factory<M, E, F> loopFactory;
   private final M startModel;
-  private final Set<F> startEffects;
+  @Nullable private final Set<F> startEffects;
 
-  RxMobiusLoop(MobiusLoop.Factory<M, E, F> loopFactory, M startModel, Set<F> startEffects) {
+  RxMobiusLoop(
+      MobiusLoop.Factory<M, E, F> loopFactory, M startModel, @Nullable Set<F> startEffects) {
     this.loopFactory = loopFactory;
     this.startModel = startModel;
     this.startEffects = startEffects;
@@ -53,7 +55,12 @@ class RxMobiusLoop<E, M, F> implements ObservableTransformer<E, M> {
         new ObservableOnSubscribe<M>() {
           @Override
           public void subscribe(final ObservableEmitter<M> emitter) throws Exception {
-            final MobiusLoop<M, E, ?> loop = loopFactory.startFrom(startModel, startEffects);
+            final MobiusLoop<M, E, ?> loop;
+            if (startEffects == null) {
+              loop = loopFactory.startFrom(startModel);
+            } else {
+              loop = loopFactory.startFrom(startModel, startEffects);
+            }
 
             loop.observe(
                 new com.spotify.mobius.functions.Consumer<M>() {

--- a/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxMobiusLoopTest.java
+++ b/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxMobiusLoopTest.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableSet;
 import com.spotify.mobius.Connectable;
 import com.spotify.mobius.Connection;
 import com.spotify.mobius.ConnectionLimitExceededException;
+import com.spotify.mobius.First;
+import com.spotify.mobius.Init;
 import com.spotify.mobius.Mobius;
 import com.spotify.mobius.MobiusLoop;
 import com.spotify.mobius.Next;
@@ -32,6 +34,7 @@ import com.spotify.mobius.Update;
 import com.spotify.mobius.functions.Consumer;
 import com.spotify.mobius.test.RecordingConnection;
 import io.reactivex.Observable;
+import io.reactivex.ObservableTransformer;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.PublishSubject;
 import java.util.Collections;
@@ -42,12 +45,12 @@ import org.junit.Test;
 
 public class RxMobiusLoopTest {
   private RecordingConnection<Boolean> connection;
-  private MobiusLoop.Factory<String, Integer, Boolean> factory;
+  private MobiusLoop.Builder<String, Integer, Boolean> builder;
 
   @Before
   public void setUp() throws Exception {
     connection = new RecordingConnection<>();
-    factory =
+    builder =
         Mobius.loop(
             new Update<String, Integer, Boolean>() {
               @Nonnull
@@ -69,7 +72,7 @@ public class RxMobiusLoopTest {
   @Test
   public void shouldPropagateIncomingErrorsAsUnrecoverable() throws Exception {
     final RxMobiusLoop<Integer, String, Boolean> loop =
-        new RxMobiusLoop<>(factory, "", Collections.emptySet());
+        new RxMobiusLoop<>(builder, "", Collections.emptySet());
 
     PublishSubject<Integer> input = PublishSubject.create();
 
@@ -87,11 +90,30 @@ public class RxMobiusLoopTest {
   @Test
   public void startModelAndEffects() {
     RxMobiusLoop<Integer, String, Boolean> loop =
-        new RxMobiusLoop<>(factory, "StartModel", ImmutableSet.of(true, false));
+        new RxMobiusLoop<>(builder, "StartModel", ImmutableSet.of(true, false));
     final TestObserver<String> testObserver = Observable.just(1).compose(loop).test();
     testObserver.assertValue("StartModel");
     testObserver.assertNoErrors();
     assertEquals(2, connection.valueCount());
     connection.assertValues(true, false);
+  }
+
+  @Test
+  public void shouldSupportStartingALoopWithAnInit() throws Exception {
+    MobiusLoop.Builder<String, Integer, Boolean> withInit =
+        builder.init(
+            new Init<String, Boolean>() {
+              @Nonnull
+              @Override
+              public First<String, Boolean> init(String model) {
+                return First.first(model + "-init");
+              }
+            });
+
+    ObservableTransformer<Integer, String> transformer = RxMobius.loopFrom(withInit, "hi");
+
+    final TestObserver<String> observer = Observable.just(10).compose(transformer).test();
+
+    observer.assertValues("hi-init");
   }
 }

--- a/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxMobiusLoopTest.java
+++ b/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxMobiusLoopTest.java
@@ -19,6 +19,7 @@
  */
 package com.spotify.mobius.rx2;
 
+import static com.spotify.mobius.Effects.effects;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
@@ -115,5 +116,26 @@ public class RxMobiusLoopTest {
     final TestObserver<String> observer = Observable.just(10).compose(transformer).test();
 
     observer.assertValues("hi-init");
+  }
+
+  @Test
+  public void shouldThrowIfStartingALoopWithInitAndStartEffects() throws Exception {
+    MobiusLoop.Builder<String, Integer, Boolean> withInit =
+        builder.init(
+            new Init<String, Boolean>() {
+              @Nonnull
+              @Override
+              public First<String, Boolean> init(String model) {
+                return First.first(model + "-init");
+              }
+            });
+
+    ObservableTransformer<Integer, String> transformer =
+        RxMobius.loopFrom(withInit, "hi", effects(true));
+
+    Observable.just(10)
+        .compose(transformer)
+        .test()
+        .assertError(t -> t.getMessage().contains("cannot pass in start effects"));
   }
 }

--- a/mobius-rx3/build.gradle
+++ b/mobius-rx3/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest-library:${versions.hamcrestLibrary}"
     testImplementation "ch.qos.logback:logback-classic:${versions.logback}"
     testImplementation "org.awaitility:awaitility:${versions.awaitility}"
+    testImplementation "org.assertj:assertj-core:${versions.assertjcore}"
     testImplementation "com.google.auto.value:auto-value-annotations:${versions.autoValue}"
 }
 

--- a/mobius-rx3/src/main/java/com/spotify/mobius/rx3/RxMobius.java
+++ b/mobius-rx3/src/main/java/com/spotify/mobius/rx3/RxMobius.java
@@ -32,7 +32,6 @@ import io.reactivex.rxjava3.functions.Action;
 import io.reactivex.rxjava3.functions.Consumer;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +58,7 @@ public final class RxMobius {
    */
   public static <M, E, F> ObservableTransformer<E, M> loopFrom(
       final MobiusLoop.Factory<M, E, F> loopFactory, final M startModel) {
-    return loopFrom(loopFactory, startModel, Collections.emptySet());
+    return new RxMobiusLoop<>(loopFactory, startModel, null);
   }
 
   /**

--- a/mobius-rx3/src/main/java/com/spotify/mobius/rx3/RxMobiusLoop.java
+++ b/mobius-rx3/src/main/java/com/spotify/mobius/rx3/RxMobiusLoop.java
@@ -31,6 +31,7 @@ import io.reactivex.rxjava3.functions.Cancellable;
 import io.reactivex.rxjava3.functions.Consumer;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Wraps a MobiusLoop into an observable transformer.
@@ -41,9 +42,10 @@ class RxMobiusLoop<E, M, F> implements ObservableTransformer<E, M> {
 
   @Nonnull private final MobiusLoop.Factory<M, E, F> loopFactory;
   @Nonnull private final M startModel;
-  @Nonnull private final Set<F> startEffects;
+  @Nullable private final Set<F> startEffects;
 
-  RxMobiusLoop(MobiusLoop.Factory<M, E, F> loopFactory, M startModel, Set<F> startEffects) {
+  RxMobiusLoop(
+      MobiusLoop.Factory<M, E, F> loopFactory, M startModel, @Nullable Set<F> startEffects) {
     this.loopFactory = loopFactory;
     this.startModel = startModel;
     this.startEffects = startEffects;
@@ -55,7 +57,14 @@ class RxMobiusLoop<E, M, F> implements ObservableTransformer<E, M> {
         new ObservableOnSubscribe<M>() {
           @Override
           public void subscribe(@NonNull ObservableEmitter<M> emitter) throws Throwable {
-            final MobiusLoop<M, E, ?> loop = loopFactory.startFrom(startModel, startEffects);
+            final MobiusLoop<M, E, ?> loop;
+
+            if (startEffects == null) {
+              loop = loopFactory.startFrom(startModel);
+            } else {
+              loop = loopFactory.startFrom(startModel, startEffects);
+            }
+
             loop.observe(
                 new com.spotify.mobius.functions.Consumer<M>() {
                   @Override

--- a/mobius-rx3/src/test/java/com/spotify/mobius/rx3/RxMobiusLoopTest.java
+++ b/mobius-rx3/src/test/java/com/spotify/mobius/rx3/RxMobiusLoopTest.java
@@ -19,6 +19,7 @@
  */
 package com.spotify.mobius.rx3;
 
+import static com.spotify.mobius.Effects.effects;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
@@ -112,5 +113,26 @@ public class RxMobiusLoopTest {
     final TestObserver<String> observer = Observable.just(10).compose(transformer).test();
 
     observer.assertValues("hi-init");
+  }
+
+  @Test
+  public void shouldThrowIfStartingALoopWithInitAndStartEffects() throws Exception {
+    MobiusLoop.Builder<String, Integer, Boolean> withInit =
+        builder.init(
+            new Init<String, Boolean>() {
+              @Nonnull
+              @Override
+              public First<String, Boolean> init(String model) {
+                return First.first(model + "-init");
+              }
+            });
+
+    ObservableTransformer<Integer, String> transformer =
+        RxMobius.loopFrom(withInit, "hi", effects(true));
+
+    Observable.just(10)
+        .compose(transformer)
+        .test()
+        .assertError(t -> t.getMessage().contains("cannot pass in start effects"));
   }
 }


### PR DESCRIPTION
Init is deprecated, but not removed, from MobiusLoop.Builder. This fixes an omission when adding 
start effects to RxMobius loops, where Init and start effects might conflict. 