### PR TITLE
WIP: Added Android KTX module and some extensions, changed documentation to Dokka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ buildscript {
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.13.0"
         classpath('com.android.tools.build:gradle:3.5.3')
         classpath 'net.researchgate:gradle-release:2.8.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
     }
 }
 
@@ -51,7 +53,8 @@ ext {
             'hamcrestLibrary'  : '1.3',
             'mockito'          : '1.10.19',
             'androidxLifecycle' : '2.2.0',
-            'androidXCoreTesting' : '2.1.0'
+            'androidXCoreTesting' : '2.1.0',
+            'kotlin'           : '1.3.70'
     ]
 }
 
@@ -115,7 +118,10 @@ allprojects {
         mapping("java", "SLASHSTAR_STYLE")
     }
 
-    getTasksByName('check', false).each { checkTask -> checkTask.dependsOn(tasks.withType(Javadoc)) }
+    getTasksByName('check', false).each { checkTask ->
+        checkTask.dependsOn(tasks.withType(Javadoc))
+        checkTask.dependsOn(tasks.withType(dokka.getClass()))
+    }
 }
 
 nexusStaging {

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'org.jetbrains.dokka'
 
 def isReleaseBuild() {
     return VERSION_NAME.contains("SNAPSHOT") == false
@@ -79,14 +80,25 @@ afterEvaluate { project ->
 
     def plugins = project.getPlugins()
     if (plugins.hasPlugin('com.android.application') || plugins.hasPlugin('com.android.library')) {
-      task androidJavadocs(type: Javadoc) {
-        source = android.sourceSets.main.java.srcDirs
-        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-      }
-
-      task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-        classifier = 'javadoc'
-        from androidJavadocs.destinationDir
+      if (plugins.hasPlugin('kotlin-android')) {
+          task androidJavadocs(type: dokka.getClass()) {
+              configuration {
+                  classpath += project.files(android.getBootClasspath()).asList()
+              }
+          }
+          task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+              classifier = 'javadoc'
+              from androidJavadocs.outputDirectory
+          }
+      } else {
+          task androidJavadocs(type: Javadoc) {
+              source = android.sourceSets.main.java.srcDirs
+              classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+          }
+          task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+              classifier = 'javadoc'
+              from androidJavadocs.destinationDir
+          }
       }
 
       task androidSourcesJar(type: Jar) {

--- a/mobius-android-ktx/build.gradle
+++ b/mobius-android-ktx/build.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+
+repositories {
+    google()
+}
+
+dependencies {
+    api project(':mobius-android')
+
+    implementation "org.slf4j:slf4j-api:${versions.slf4j}"
+    implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:${versions.androidxLifecycle}"
+
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+}
+
+static def gitSha() {
+    return 'git rev-parse --short HEAD'.execute().text.trim()
+}
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    sourceSets {
+        main.java.srcDirs += "src/main/kotlin"
+        test.java.srcDirs += "src/test/kotlin"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    defaultConfig {
+        minSdkVersion rootProject.ext.minSdkVersion
+        buildConfigField "String", "LIBRARY_VERSION", "\"${VERSION_NAME}\""
+        buildConfigField "String", "GIT_SHA", "\"${gitSha()}\""
+    }
+    lintOptions {
+        disable 'InvalidPackage'
+    }
+}
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/mobius-android-ktx/gradle.properties
+++ b/mobius-android-ktx/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=mobius-android-ktx
+POM_NAME=Kotlin features for Android-specific part of Mobius
+POM_DESCRIPTION=Mobius for Android with Kotlin

--- a/mobius-android-ktx/src/main/AndroidManifest.xml
+++ b/mobius-android-ktx/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.spotify.mobius.android.ktx" />

--- a/mobius-android-ktx/src/main/kotlin/com/spotify/mobius/android/ktx/MobiusLoopViewModelExtensions.kt
+++ b/mobius-android-ktx/src/main/kotlin/com/spotify/mobius/android/ktx/MobiusLoopViewModelExtensions.kt
@@ -1,0 +1,83 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.android.ktx
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import com.spotify.mobius.android.LiveQueue
+
+/**
+ * A type-alias to simplify code, for a function that acts like an Observable.
+ * The parameter of this function is the callback function to be called when an item is emitted.
+ */
+typealias ObservableFunc<T> = (((T) -> Unit) -> Unit)
+
+/**
+ * Curries the target [LiveQueue] with a lifecycle owner. The returned function expects a lambda,
+ * which will then be used to subscribe to both foreground and background effects from the target
+ * [LiveQueue].
+ *
+ * The subscription only happens will only happen when the [ObservableFunc] is invoked with an observer.
+ */
+fun <T> LiveQueue<T>.observeAllWith(lifecycleOwner: LifecycleOwner): ObservableFunc<T> = { observeCallback ->
+    setObserver(
+        lifecycleOwner,
+        Observer { observeCallback(it) },
+        Observer { effects -> effects.forEach { observeCallback(it) } }
+    )
+}
+
+/**
+ * Curries the target [LiveQueue] with a lifecycle owner. The returned function expects a lambda,
+ * which will then be used to subscribe to only the foreground effects from the target [LiveQueue].
+ *
+ * The subscription only happens will only happen when the [ObservableFunc] is invoked with an observer.
+ */
+fun <T> LiveQueue<T>.observeForegroundWith(lifecycleOwner: LifecycleOwner): ObservableFunc<T> =
+    { observeCallback ->
+        setObserver(lifecycleOwner, Observer { observeCallback(it) })
+    }
+
+/**
+ * Curries the target [LiveData] with a lifecycle owner. The returned function then expects a
+ * lambda that receives events.
+ *
+ * The call to observe the [LiveData] will only happen when the [ObservableFunc]
+ * is invoked with an observer.
+ */
+fun <T> LiveData<T>.observeWith(lifecycleOwner: LifecycleOwner): ObservableFunc<T> =
+    { observeCallback -> observe(lifecycleOwner, Observer { observeCallback(it) }) }
+
+/**
+ * Applies the given transformation to each object received by the receiver observable function,
+ * giving you a new observable function.
+ */
+fun <M, S> ObservableFunc<M>.map(mapper: ((M) -> S)): ObservableFunc<S> = { func ->
+    this { m: M -> func(mapper(m)) }
+}
+
+/**
+ * Applies the given filter function to each object received by this observable function,
+ * creating a new observable function that only get objects for which the filter returned true.
+ */
+fun <T> ObservableFunc<T>.filter(filter: ((T) -> Boolean)): ObservableFunc<T> = { func ->
+    this { m: T -> if (filter(m)) func(m) }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
+include ':mobius-android-ktx'
 rootProject.name = 'mobius'
 
 include 'mobius-core'


### PR DESCRIPTION
- Added a `mobius-android-ktx` module, dependent on the `mobius-android` module
- Added some useful extensions for `LiveData` and `LiveQueue` to allow easier, consistent usage and currying in Kotlin

**Note**: I was thinking about writing tests, but there's currently no public exposed `LiveQueue` implementation. If we want tests for this, we would have to rethink how we expose some classes. 

Additionally, it would be good to expose the `FakeLifecycleOwner` class for general testing too. Not sure if making a test module is perhaps an option?