### PR TITLE
Use DiscardAfterDispose in RxConnectables

### DIFF
--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/DiscardAfterDisposeConnectable.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/DiscardAfterDisposeConnectable.java
@@ -1,0 +1,69 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.rx2;
+
+import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
+import static com.spotify.mobius.rx2.DiscardAfterDisposeWrapper.wrapConnection;
+import static com.spotify.mobius.rx2.DiscardAfterDisposeWrapper.wrapConsumer;
+
+import com.spotify.mobius.Connectable;
+import com.spotify.mobius.Connection;
+import com.spotify.mobius.disposables.CompositeDisposable;
+import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.functions.Consumer;
+import javax.annotation.Nonnull;
+
+/**
+ * A {@link Connectable} that ensures that {@link Connection}s created by the wrapped {@link
+ * Connectable} don't emit or receive any values after being disposed.
+ *
+ * <p>This only acts as a safeguard, you still need to make sure that the Connectable disposes of
+ * resources correctly.
+ */
+class DiscardAfterDisposeConnectable<I, O> implements Connectable<I, O> {
+
+  private final Connectable<I, O> actual;
+
+  DiscardAfterDisposeConnectable(Connectable<I, O> actual) {
+    this.actual = checkNotNull(actual);
+  }
+
+  @Nonnull
+  @Override
+  public Connection<I> connect(Consumer<O> output) {
+    final DiscardAfterDisposeWrapper<O> safeOutput = wrapConsumer(output);
+    final Connection<I> input = actual.connect(safeOutput);
+    final DiscardAfterDisposeWrapper<I> safeInput = wrapConnection(input);
+
+    final Disposable disposable = CompositeDisposable.from(safeInput, safeOutput);
+
+    return new Connection<I>() {
+      @Override
+      public void accept(I effect) {
+        safeInput.accept(effect);
+      }
+
+      @Override
+      public void dispose() {
+        disposable.dispose();
+      }
+    };
+  }
+}

--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/DiscardAfterDisposeWrapper.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/DiscardAfterDisposeWrapper.java
@@ -1,0 +1,67 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.rx2;
+
+import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
+
+import com.spotify.mobius.Connection;
+import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.functions.Consumer;
+import javax.annotation.Nullable;
+
+/**
+ * Wraps a {@link Connection} or a {@link Consumer} and blocks them from receiving any further
+ * values after the wrapper has been disposed.
+ */
+class DiscardAfterDisposeWrapper<I> implements Consumer<I>, Disposable {
+  private final Consumer<I> consumer;
+  @Nullable private final Disposable disposable;
+  private boolean disposed;
+
+  static <I> DiscardAfterDisposeWrapper<I> wrapConnection(Connection<I> connection) {
+    checkNotNull(connection);
+    return new DiscardAfterDisposeWrapper<>(connection, connection);
+  }
+
+  static <I> DiscardAfterDisposeWrapper<I> wrapConsumer(Consumer<I> consumer) {
+    return new DiscardAfterDisposeWrapper<>(checkNotNull(consumer), null);
+  }
+
+  private DiscardAfterDisposeWrapper(Consumer<I> consumer, @Nullable Disposable disposable) {
+    this.consumer = consumer;
+    this.disposable = disposable;
+  }
+
+  @Override
+  public synchronized void accept(I effect) {
+    if (disposed) {
+      return;
+    }
+    consumer.accept(effect);
+  }
+
+  @Override
+  public synchronized void dispose() {
+    disposed = true;
+    if (disposable != null) {
+      disposable.dispose();
+    }
+  }
+}

--- a/mobius-rx2/src/test/java/com/spotify/mobius/rx2/DiscardAfterDisposeConnectableTest.java
+++ b/mobius-rx2/src/test/java/com/spotify/mobius/rx2/DiscardAfterDisposeConnectableTest.java
@@ -1,0 +1,193 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.rx2;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import com.spotify.mobius.Connectable;
+import com.spotify.mobius.Connection;
+import com.spotify.mobius.functions.Consumer;
+import com.spotify.mobius.test.RecordingConsumer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DiscardAfterDisposeConnectableTest {
+
+  private RecordingConsumer<String> recordingConsumer;
+  private Connection<Integer> connection;
+  private Semaphore blockEffectPerformer;
+  private Semaphore signalEffectHasBeenPerformed;
+  private BlockableConnection blockableConnection;
+
+  private DiscardAfterDisposeConnectable<Integer, String> underTest;
+
+  private final ExecutorService executorService = Executors.newCachedThreadPool();
+
+  @Before
+  public void setUp() throws Exception {
+    blockEffectPerformer = new Semaphore(0);
+    signalEffectHasBeenPerformed = new Semaphore(0);
+
+    recordingConsumer = new RecordingConsumer<>();
+    blockableConnection = new BlockableConnection(recordingConsumer);
+
+    underTest =
+        new DiscardAfterDisposeConnectable<>(
+            new Connectable<Integer, String>() {
+              @Nonnull
+              @Override
+              public Connection<Integer> connect(Consumer<String> output) {
+                return blockableConnection;
+              }
+            });
+  }
+
+  @Test
+  public void nullActualThrowsNPE() throws Exception {
+    assertThatThrownBy(() -> new DiscardAfterDisposeConnectable<Integer, String>(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void nullConsumerInConnectThrowsNPE() throws Exception {
+    assertThatThrownBy(() -> underTest.connect(null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void nullDisposableConsumerReturnedToConnectThrowsNPE() throws Exception {
+    underTest =
+        new DiscardAfterDisposeConnectable<>(
+            new Connectable<Integer, String>() {
+              @Nonnull
+              @Override
+              public Connection<Integer> connect(Consumer<String> output) {
+                //noinspection ConstantConditions
+                return null;
+              }
+            });
+
+    assertThatThrownBy(() -> underTest.connect(recordingConsumer))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void delegatesEffectsToActualSink() throws Exception {
+    connection = underTest.connect(recordingConsumer);
+    connection.accept(1);
+    recordingConsumer.assertValues("Value is: 1");
+  }
+
+  @Test
+  public void delegatesDisposeToActualSink() throws Exception {
+    connection = underTest.connect(recordingConsumer);
+    connection.dispose();
+    assertThat(blockableConnection.disposed, is(true));
+  }
+
+  @Test
+  public void discardsEventsAfterDisposal() throws Exception {
+    connection = underTest.connect(recordingConsumer);
+
+    // given the effect performer is blocked
+    blockableConnection.block = true;
+
+    // when an effect is requested
+    Future<?> effectPerformedFuture = executorService.submit(() -> connection.accept(1));
+
+    // and the sink is disposed
+    connection.dispose();
+
+    // before the effect gets performed
+    // (needs permitting the blocked effect performer to proceed)
+    blockEffectPerformer.release();
+
+    // (get the result of the future to ensure the effect has been performed, also propagating
+    // exceptions if any - result should happen quickly, but it's good to have a timeout in case
+    // something is messed up)
+    effectPerformedFuture.get(10, TimeUnit.SECONDS);
+
+    // then no events are emitted
+    recordingConsumer.assertValues();
+  }
+
+  @Test
+  public void discardsEffectsAfterDisposal() throws Exception {
+    // given a disposed sink
+    connection = underTest.connect(recordingConsumer);
+    connection.dispose();
+
+    // when an effect is performed
+    connection.accept(1);
+
+    // then no effects or events happen
+    blockableConnection.assertEffects();
+    recordingConsumer.assertValues();
+  }
+
+  private class BlockableConnection implements Connection<Integer> {
+
+    private final List<Integer> recordedEffects = new ArrayList<>();
+    private boolean disposed;
+    private final Consumer<String> eventConsumer;
+    private volatile boolean block = false;
+
+    BlockableConnection(Consumer<String> eventConsumer) {
+      this.eventConsumer = eventConsumer;
+    }
+
+    void assertEffects(Integer... values) {
+      assertThat(recordedEffects, equalTo(Arrays.asList(values)));
+    }
+
+    @Override
+    public void accept(final Integer effect) {
+      if (block) {
+        try {
+          if (!blockEffectPerformer.tryAcquire(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("timed out waiting for effect performer unblock");
+          }
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      recordedEffects.add(effect);
+      eventConsumer.accept("Value is: " + effect);
+      signalEffectHasBeenPerformed.release();
+    }
+
+    @Override
+    public void dispose() {
+      disposed = true;
+      signalEffectHasBeenPerformed.release();
+    }
+  }
+}


### PR DESCRIPTION
After the loop is disposed, any event will cause an IllegalStateException. To narrow down 
the possible cause, we'd like to introduce DiscardAfterDispose to ensure no event delivered 
after a connection is disposed. 