### PR TITLE
Add support for configurable error handling

### DIFF
--- a/mobius-core/src/main/java/com/spotify/mobius/MessageDispatcher.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MessageDispatcher.java
@@ -48,16 +48,13 @@ class MessageDispatcher<M> implements Consumer<M>, Disposable {
   @Override
   public void accept(final M message) {
     runner.post(
-        new Runnable() {
-          @Override
-          public void run() {
-            try {
-              consumer.accept(message);
-
-            } catch (Throwable throwable) {
-              LOGGER.error(
-                  "Consumer threw an exception when accepting message: {}", message, throwable);
-            }
+        () -> {
+          try {
+            consumer.accept(message);
+          } catch (Throwable throwable) {
+            MobiusHooks.handleError(
+                new RuntimeException(
+                    "Consumer threw an exception when accepting message: " + message, throwable));
           }
         });
   }

--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusHooks.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusHooks.java
@@ -1,0 +1,66 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius;
+
+import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
+
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Allows configuration of how Mobius handles programmer errors through setting a custom {@link
+ * ErrorHandler} via the {@link #setErrorHandler(ErrorHandler)} method. The default handler logs the
+ * error via SLF4J.
+ */
+public final class MobiusHooks {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MobiusHooks.class);
+
+  private static final ErrorHandler DEFAULT_ERROR_HANDLER =
+      error -> LOGGER.error("Uncaught error", error);
+
+  @Nonnull private static ErrorHandler errorHandler = DEFAULT_ERROR_HANDLER;
+
+  private MobiusHooks() {
+    // prevent instantiation
+  }
+
+  public interface ErrorHandler {
+    void handleError(Throwable error);
+  }
+
+  public static synchronized void handleError(Throwable error) {
+    errorHandler.handleError(error);
+  }
+
+  /**
+   * Changes the error handler that is used by Mobius for internal errors.
+   *
+   * @param newHandler the new handler to use.
+   */
+  public static synchronized void setErrorHandler(ErrorHandler newHandler) {
+    errorHandler = checkNotNull(newHandler);
+  }
+
+  /** Sets the error handler to the default one. */
+  public static synchronized void setDefaultErrorHandler() {
+    errorHandler = DEFAULT_ERROR_HANDLER;
+  }
+}

--- a/mobius-core/src/test/java/com/spotify/mobius/MessageDispatcherTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/MessageDispatcherTest.java
@@ -1,0 +1,70 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.HamcrestCondition.matching;
+import static org.assertj.core.data.Index.atIndex;
+import static org.hamcrest.Matchers.containsString;
+
+import com.spotify.mobius.runners.WorkRunners;
+import java.util.LinkedList;
+import java.util.List;
+import org.junit.Test;
+
+public class MessageDispatcherTest {
+
+  @Test
+  public void shouldForwardMessagesToConsumer() throws Exception {
+    List<String> messages = new LinkedList<>();
+
+    new MessageDispatcher<String>(WorkRunners.immediate(), messages::add).accept("hey hello");
+
+    assertThat(messages).containsExactly("hey hello");
+  }
+
+  @Test
+  public void shouldSendErrorsFromConsumerToMobiusHooks() throws Exception {
+    // given an error handler
+    TestErrorHandler errorHandler = new TestErrorHandler();
+
+    MobiusHooks.setErrorHandler(errorHandler);
+
+    final RuntimeException expected = new RuntimeException("boo");
+
+    // and a message consumer that throws an exception,
+    // when a message is dispatched
+    new MessageDispatcher<String>(
+            WorkRunners.immediate(),
+            s -> {
+              throw expected;
+            })
+        .accept("here's an event that should be reported as the cause of failure");
+
+    // then the exception gets sent to the error handler.
+    assertThat(errorHandler.handledErrors).extracting(Throwable::getCause).contains(expected);
+    assertThat(errorHandler.handledErrors)
+        .extracting(Throwable::getMessage)
+        .has(
+            matching(
+                containsString("here's an event that should be reported as the cause of failure")),
+            atIndex(0));
+  }
+}

--- a/mobius-core/src/test/java/com/spotify/mobius/MobiusHooksTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/MobiusHooksTest.java
@@ -24,9 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import com.spotify.mobius.MobiusHooks.ErrorHandler;
-import java.util.LinkedList;
-import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,24 +67,14 @@ public class MobiusHooksTest {
 
   @Test
   public void shouldAllowChangingTheHandler() throws Exception {
-    MyErrorHandler myErrorHandler = new MyErrorHandler();
-    MobiusHooks.setErrorHandler(myErrorHandler);
+    TestErrorHandler testErrorHandler = new TestErrorHandler();
+    MobiusHooks.setErrorHandler(testErrorHandler);
 
     final RuntimeException theError = new RuntimeException("hey there");
 
     MobiusHooks.handleError(theError);
 
-    assertThat(myErrorHandler.handledErrors).containsExactly(theError);
+    assertThat(testErrorHandler.handledErrors).containsExactly(theError);
     assertThat(appender.list).isEmpty();
-  }
-
-  private static class MyErrorHandler implements ErrorHandler {
-
-    private List<Throwable> handledErrors = new LinkedList<>();
-
-    @Override
-    public void handleError(Throwable error) {
-      handledErrors.add(error);
-    }
   }
 }

--- a/mobius-core/src/test/java/com/spotify/mobius/MobiusHooksTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/MobiusHooksTest.java
@@ -1,0 +1,93 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.spotify.mobius.MobiusHooks.ErrorHandler;
+import java.util.LinkedList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+public class MobiusHooksTest {
+
+  private ListAppender<ILoggingEvent> appender;
+  private Logger logbackLogger;
+
+  @Before
+  public void setUp() throws Exception {
+    appender = new ListAppender<>();
+    appender.start();
+
+    logbackLogger = (Logger) LoggerFactory.getLogger(MobiusHooks.class);
+
+    logbackLogger.addAppender(appender);
+    MobiusHooks.setDefaultErrorHandler();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    logbackLogger.detachAppender(appender);
+  }
+
+  @Test
+  public void shouldHaveADefaultHandlerThatLogs() throws Exception {
+    Exception expected = new RuntimeException("I'm expected");
+
+    MobiusHooks.handleError(expected);
+
+    assertThat(appender.list)
+        .extracting(ILoggingEvent::getFormattedMessage)
+        .containsExactly("Uncaught error");
+
+    assertThat(appender.list)
+        .extracting((ILoggingEvent event) -> event.getThrowableProxy().getMessage())
+        .containsExactly("I'm expected");
+  }
+
+  @Test
+  public void shouldAllowChangingTheHandler() throws Exception {
+    MyErrorHandler myErrorHandler = new MyErrorHandler();
+    MobiusHooks.setErrorHandler(myErrorHandler);
+
+    final RuntimeException theError = new RuntimeException("hey there");
+
+    MobiusHooks.handleError(theError);
+
+    assertThat(myErrorHandler.handledErrors).containsExactly(theError);
+    assertThat(appender.list).isEmpty();
+  }
+
+  private static class MyErrorHandler implements ErrorHandler {
+
+    private List<Throwable> handledErrors = new LinkedList<>();
+
+    @Override
+    public void handleError(Throwable error) {
+      handledErrors.add(error);
+    }
+  }
+}

--- a/mobius-core/src/test/java/com/spotify/mobius/TestErrorHandler.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/TestErrorHandler.java
@@ -1,0 +1,35 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius;
+
+import com.spotify.mobius.MobiusHooks.ErrorHandler;
+import java.util.LinkedList;
+import java.util.List;
+
+/** Error handler for use in tests */
+class TestErrorHandler implements ErrorHandler {
+
+  List<Throwable> handledErrors = new LinkedList<>();
+
+  @Override
+  public void handleError(Throwable error) {
+    handledErrors.add(error);
+  }
+}


### PR DESCRIPTION
For exceptions that happen on WorkRunner threads, we log an error rather than let them be forwarded to the threads' UncaughtExceptionHandler. This PR adds the ability to configure
that behaviour, so that it's possible to do something else - like crash the application, for instance.

It's not super clear to me that this is better or more discoverable than a way to specify the `UncaughtExceptionHandler` for `WorkRunner` threads. But I thought I'd push it to see what people think.