### PR TITLE
Make MessageDispatcher not forward messages when disposed.

### DIFF
--- a/mobius-core/src/main/java/com/spotify/mobius/MessageDispatcher.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MessageDispatcher.java
@@ -25,8 +25,6 @@ import com.spotify.mobius.disposables.Disposable;
 import com.spotify.mobius.functions.Consumer;
 import com.spotify.mobius.runners.WorkRunner;
 import javax.annotation.Nonnull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Dispatches messages to a given runner.
@@ -35,10 +33,10 @@ import org.slf4j.LoggerFactory;
  */
 class MessageDispatcher<M> implements Consumer<M>, Disposable {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(MessageDispatcher.class);
-
   @Nonnull private final WorkRunner runner;
   @Nonnull private final Consumer<M> consumer;
+
+  private volatile boolean disposed = false;
 
   MessageDispatcher(WorkRunner runner, Consumer<M> consumer) {
     this.runner = checkNotNull(runner);
@@ -47,6 +45,10 @@ class MessageDispatcher<M> implements Consumer<M>, Disposable {
 
   @Override
   public void accept(final M message) {
+    if (disposed) {
+      return;
+    }
+
     runner.post(
         () -> {
           try {
@@ -61,6 +63,7 @@ class MessageDispatcher<M> implements Consumer<M>, Disposable {
 
   @Override
   public void dispose() {
+    disposed = true;
     runner.dispose();
   }
 }

--- a/mobius-core/src/test/java/com/spotify/mobius/MessageDispatcherTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/MessageDispatcherTest.java
@@ -27,13 +27,20 @@ import static org.hamcrest.Matchers.containsString;
 import com.spotify.mobius.runners.WorkRunners;
 import java.util.LinkedList;
 import java.util.List;
+import org.junit.Before;
 import org.junit.Test;
 
 public class MessageDispatcherTest {
 
+  private List<String> messages;
+
+  @Before
+  public void setUp() throws Exception {
+    messages = new LinkedList<>();
+  }
+
   @Test
   public void shouldForwardMessagesToConsumer() throws Exception {
-    List<String> messages = new LinkedList<>();
 
     new MessageDispatcher<String>(WorkRunners.immediate(), messages::add).accept("hey hello");
 
@@ -66,5 +73,20 @@ public class MessageDispatcherTest {
             matching(
                 containsString("here's an event that should be reported as the cause of failure")),
             atIndex(0));
+  }
+
+  @Test
+  public void shouldIgnoreMessagesAfterDispose() throws Exception {
+    // given a message dispatcher that has been disposed
+    MessageDispatcher<String> messageDispatcher =
+        new MessageDispatcher<>(WorkRunners.singleThread(), messages::add);
+
+    messageDispatcher.dispose();
+
+    // when a message arrives
+    messageDispatcher.accept("foo");
+
+    // it is ignored
+    assertThat(messages).isEmpty();
   }
 }


### PR DESCRIPTION
Not all WorkRunner implementations are safe when sending in work after dispose.
Without this change, there is a race between `MobiusLoop.dispose` and `dispatchEvent` 
leading to `RejectedExecutionException`s: 

1. the thread running `dispatchEvent` is stopped after checking that `runState != DISPOSED` 
but before posting the event to the event dispatcher
2. `dispose` runs and completes
3. `dispatchEvent` resumes, and attempts to send the event on a diposed `WorkRunner`, which in the case of `ExecutionService`-based runners leads to an exception.