### PR TITLE
fix flakiness in Rx tests

### DIFF
--- a/mobius-rx/src/test/java/com/spotify/mobius/rx/RxMobiusLoopTest.java
+++ b/mobius-rx/src/test/java/com/spotify/mobius/rx/RxMobiusLoopTest.java
@@ -86,11 +86,13 @@ public class RxMobiusLoopTest {
   }
 
   @Test
-  public void startModelAndEffects() {
+  public void startModelAndEffects() throws Exception {
     RxMobiusLoop<Integer, String, Boolean> loop =
         new RxMobiusLoop<>(builder, "StartModel", ImmutableSet.of(true, false));
     final AssertableSubscriber<String> subscriber = Observable.just(1).compose(loop).test();
-    subscriber.assertValue("StartModel");
+
+    waitForSubscriberValueCount(subscriber, 2);
+    subscriber.assertValues("StartModel", "StartModel1");
     subscriber.assertNoErrors();
     assertEquals(2, connection.valueCount());
     connection.assertValues(true, false);
@@ -112,7 +114,19 @@ public class RxMobiusLoopTest {
 
     final AssertableSubscriber<String> observer = Observable.just(10).compose(transformer).test();
 
-    observer.assertValues("hi-init");
+    waitForSubscriberValueCount(observer, 2);
+    observer.assertValues("hi-init", "hi-init10");
+  }
+
+  private static void waitForSubscriberValueCount(
+      AssertableSubscriber<String> subscriber, int count) throws InterruptedException {
+    for (int i = 0; i < 50; i++) {
+      if (subscriber.getValueCount() == count) {
+        break;
+      }
+
+      Thread.sleep(50);
+    }
   }
 
   @Test

--- a/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxMobiusLoopTest.java
+++ b/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxMobiusLoopTest.java
@@ -93,7 +93,9 @@ public class RxMobiusLoopTest {
     RxMobiusLoop<Integer, String, Boolean> loop =
         new RxMobiusLoop<>(builder, "StartModel", ImmutableSet.of(true, false));
     final TestObserver<String> testObserver = Observable.just(1).compose(loop).test();
-    testObserver.assertValue("StartModel");
+
+    testObserver.awaitCount(2);
+    testObserver.assertValues("StartModel", "StartModel1");
     testObserver.assertNoErrors();
     assertEquals(2, connection.valueCount());
     connection.assertValues(true, false);
@@ -115,7 +117,8 @@ public class RxMobiusLoopTest {
 
     final TestObserver<String> observer = Observable.just(10).compose(transformer).test();
 
-    observer.assertValues("hi-init");
+    observer.awaitCount(2);
+    observer.assertValues("hi-init", "hi-init10");
   }
 
   @Test

--- a/mobius-rx3/src/test/java/com/spotify/mobius/rx3/RxMobiusLoopTest.java
+++ b/mobius-rx3/src/test/java/com/spotify/mobius/rx3/RxMobiusLoopTest.java
@@ -90,7 +90,9 @@ public class RxMobiusLoopTest {
     RxMobiusLoop<Integer, String, Boolean> loop =
         new RxMobiusLoop<>(builder, "StartModel", ImmutableSet.of(true, false));
     final TestObserver<String> testObserver = Observable.just(1).compose(loop).test();
-    testObserver.assertValue("StartModel");
+
+    testObserver.awaitCount(2);
+    testObserver.assertValues("StartModel", "StartModel1");
     testObserver.assertNoErrors();
     assertEquals(2, connection.valueCount());
     connection.assertValues(true, false);
@@ -112,7 +114,8 @@ public class RxMobiusLoopTest {
 
     final TestObserver<String> observer = Observable.just(10).compose(transformer).test();
 
-    observer.assertValues("hi-init");
+    observer.awaitCount(2);
+    observer.assertValues("hi-init", "hi-init10");
   }
 
   @Test


### PR DESCRIPTION
Some of the tests in the Rx packages did not use stable assertions meaning that they would occasionally fail. 