### PR TITLE
Fix flaky DiscardAfterDisposeConnectableTest

### DIFF
--- a/mobius-core/src/test/java/com/spotify/mobius/DiscardAfterDisposeConnectableTest.java
+++ b/mobius-core/src/test/java/com/spotify/mobius/DiscardAfterDisposeConnectableTest.java
@@ -21,19 +21,10 @@ package com.spotify.mobius;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 import com.spotify.mobius.functions.Consumer;
 import com.spotify.mobius.test.RecordingConsumer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,21 +33,14 @@ public class DiscardAfterDisposeConnectableTest {
 
   private RecordingConsumer<String> recordingConsumer;
   private Connection<Integer> connection;
-  private Semaphore blockEffectPerformer;
-  private Semaphore signalEffectHasBeenPerformed;
-  private BlockableConnection blockableConnection;
+  private TestConnection testConnection;
 
   private DiscardAfterDisposeConnectable<Integer, String> underTest;
 
-  private final ExecutorService executorService = Executors.newCachedThreadPool();
-
   @Before
   public void setUp() throws Exception {
-    blockEffectPerformer = new Semaphore(0);
-    signalEffectHasBeenPerformed = new Semaphore(0);
-
     recordingConsumer = new RecordingConsumer<>();
-    blockableConnection = new BlockableConnection(recordingConsumer);
+    testConnection = new TestConnection(recordingConsumer);
 
     underTest =
         new DiscardAfterDisposeConnectable<>(
@@ -64,7 +48,7 @@ public class DiscardAfterDisposeConnectableTest {
               @Nonnull
               @Override
               public Connection<Integer> connect(Consumer<String> output) {
-                return blockableConnection;
+                return testConnection;
               }
             });
   }
@@ -98,94 +82,49 @@ public class DiscardAfterDisposeConnectableTest {
   }
 
   @Test
-  public void delegatesEffectsToActualSink() throws Exception {
+  public void forwardsMessagesToWrappedConsumer() throws Exception {
     connection = underTest.connect(recordingConsumer);
-    connection.accept(1);
-    recordingConsumer.assertValues("Value is: 1");
+    connection.accept(14);
+    recordingConsumer.assertValues("Value is: 14");
   }
 
   @Test
-  public void delegatesDisposeToActualSink() throws Exception {
+  public void delegatesDisposeToActualConnection() throws Exception {
     connection = underTest.connect(recordingConsumer);
     connection.dispose();
-    assertThat(blockableConnection.disposed, is(true));
+    assertThat(testConnection.disposed, is(true));
   }
 
   @Test
   public void discardsEventsAfterDisposal() throws Exception {
-    connection = underTest.connect(recordingConsumer);
-
-    // given the effect performer is blocked
-    blockableConnection.block = true;
-
-    // when an effect is requested
-    Future<?> effectPerformedFuture = executorService.submit(() -> connection.accept(1));
-
-    // and the sink is disposed
-    connection.dispose();
-
-    // before the effect gets performed
-    // (needs permitting the blocked effect performer to proceed)
-    blockEffectPerformer.release();
-
-    // (get the result of the future to ensure the effect has been performed, also propagating
-    // exceptions if any - result should happen quickly, but it's good to have a timeout in case
-    // something is messed up)
-    effectPerformedFuture.get(10, TimeUnit.SECONDS);
-
-    // then no events are emitted
-    recordingConsumer.assertValues();
-  }
-
-  @Test
-  public void discardsEffectsAfterDisposal() throws Exception {
-    // given a disposed sink
+    // given a disposed connection
     connection = underTest.connect(recordingConsumer);
     connection.dispose();
 
-    // when an effect is performed
+    // when a message arrives
     connection.accept(1);
 
-    // then no effects or events happen
-    blockableConnection.assertEffects();
+    // it is discarded
     recordingConsumer.assertValues();
   }
 
-  private class BlockableConnection implements Connection<Integer> {
+  private static class TestConnection implements Connection<Integer> {
 
-    private final List<Integer> recordedEffects = new ArrayList<>();
     private boolean disposed;
     private final Consumer<String> eventConsumer;
-    private volatile boolean block = false;
 
-    BlockableConnection(Consumer<String> eventConsumer) {
+    TestConnection(Consumer<String> eventConsumer) {
       this.eventConsumer = eventConsumer;
-    }
-
-    void assertEffects(Integer... values) {
-      assertThat(recordedEffects, equalTo(Arrays.asList(values)));
     }
 
     @Override
     public void accept(final Integer effect) {
-      if (block) {
-        try {
-          if (!blockEffectPerformer.tryAcquire(5, TimeUnit.SECONDS)) {
-            throw new IllegalStateException("timed out waiting for effect performer unblock");
-          }
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }
-      recordedEffects.add(effect);
       eventConsumer.accept("Value is: " + effect);
-      signalEffectHasBeenPerformed.release();
     }
 
     @Override
     public void dispose() {
       disposed = true;
-      signalEffectHasBeenPerformed.release();
     }
   }
 }


### PR DESCRIPTION
This test seems to have had a lot of complexity and code from
an earlier version of the wrapper, based on names, etc. This
commit cleans up the test code, simplifies it and removes a
broken test case.