### PR TITLE
improve stability of TransformersTest

### DIFF
--- a/mobius-rx/src/test/java/com/spotify/mobius/rx/TransformersTest.java
+++ b/mobius-rx/src/test/java/com/spotify/mobius/rx/TransformersTest.java
@@ -141,7 +141,7 @@ public class TransformersTest {
 
   @Test
   public void processingLongEffectsDoesNotBlockProcessingShorterEffects() {
-    final List<String> effects = Arrays.asList("Hello", "Rx1");
+    final List<String> effects = Arrays.asList("Hello", "Rx");
 
     PublishSubject<String> upstream = PublishSubject.create();
     Function<String, Integer> sleepyFunction =
@@ -169,9 +169,9 @@ public class TransformersTest {
       if (duration(f) > maxDuration) maxDuration = duration(f);
     }
     // Since effects are processed in parallel thanks to FlatMap
-    // we only wait the max time and add 100 milliseconds to
-    // avoid test flakiness thanks to time
-    return Duration.ofMillis(maxDuration + 100);
+    // we only wait the max time and add some time to
+    // avoid test flakiness due to time
+    return Duration.ofMillis(maxDuration + 500);
   }
 
   private int duration(String f) {

--- a/mobius-rx2/src/test/java/com/spotify/mobius/rx2/TransformersTest.java
+++ b/mobius-rx2/src/test/java/com/spotify/mobius/rx2/TransformersTest.java
@@ -122,7 +122,7 @@ public class TransformersTest {
 
   @Test
   public void processingLongEffectsDoesNotBlockProcessingShorterEffects() {
-    final List<String> effects = Arrays.asList("Hello", "Rx2");
+    final List<String> effects = Arrays.asList("Hello", "Rx");
 
     PublishSubject<String> upstream = PublishSubject.create();
     Function<String, Integer> sleepyFunction =
@@ -150,9 +150,9 @@ public class TransformersTest {
       if (duration(f) > maxDuration) maxDuration = duration(f);
     }
     // Since effects are processed in parallel thanks to FlatMap
-    // we only wait the max time and add 100 milliseconds to
-    // avoid test flakiness thanks to time
-    return Duration.ofMillis(maxDuration + 100);
+    // we only wait the max time and add some time to
+    // avoid test flakiness due to time
+    return Duration.ofMillis(maxDuration + 500);
   }
 
   private int duration(String f) {

--- a/mobius-rx3/src/test/java/com/spotify/mobius/rx3/TransformersTest.java
+++ b/mobius-rx3/src/test/java/com/spotify/mobius/rx3/TransformersTest.java
@@ -123,7 +123,7 @@ public class TransformersTest {
 
   @Test
   public void processingLongEffectsDoesNotBlockProcessingShorterEffects() {
-    final List<String> effects = Arrays.asList("Hello", "Rx2");
+    final List<String> effects = Arrays.asList("Hello", "Rx");
 
     PublishSubject<String> upstream = PublishSubject.create();
     Function<String, Integer> sleepyFunction =
@@ -151,9 +151,9 @@ public class TransformersTest {
       if (duration(f) > maxDuration) maxDuration = duration(f);
     }
     // Since effects are processed in parallel thanks to FlatMap
-    // we only wait the max time and add 100 milliseconds to
-    // avoid test flakiness thanks to time
-    return Duration.ofMillis(maxDuration + 100);
+    // we only wait the max time and add some time to
+    // avoid test flakiness due to time
+    return Duration.ofMillis(maxDuration + 500);
   }
 
   private int duration(String f) {


### PR DESCRIPTION
This change increases the timeout and the difference
between the fast and slow effects in these test cases,
since slow execution turns out to sometimes cause flakes
in CI.