### PR TITLE
Fix UnrecoverableIncomingException hashCode()s

### DIFF
--- a/mobius-rx/src/main/java/com/spotify/mobius/rx/UnrecoverableIncomingException.java
+++ b/mobius-rx/src/main/java/com/spotify/mobius/rx/UnrecoverableIncomingException.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.mobius.rx;
 
+import java.util.Arrays;
+
 /**
  * Used to indicate that an {@link RxMobiusLoop} transformer has received an {@link
  * rx.Observer#onError(Throwable)} call, which is illegal. This exception means Mobius is in an
@@ -39,6 +41,14 @@ public class UnrecoverableIncomingException extends RuntimeException {
       return false;
     }
 
-    return o == this || getCause().equals(((UnrecoverableIncomingException) o).getCause());
+    final UnrecoverableIncomingException other = (UnrecoverableIncomingException) o;
+    return o == this
+        || (getCause() == null && other.getCause() == null)
+        || getCause().equals(other.getCause());
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(new Object[] {getCause()});
   }
 }

--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/UnrecoverableIncomingException.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/UnrecoverableIncomingException.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.mobius.rx2;
 
+import java.util.Arrays;
+
 /**
  * Used to indicate that an {@link RxMobiusLoop} transformer has received an {@link
  * io.reactivex.Observer#onError(Throwable)} call, which is illegal. This exception means Mobius is
@@ -39,6 +41,14 @@ public class UnrecoverableIncomingException extends RuntimeException {
       return false;
     }
 
-    return o == this || getCause().equals(((UnrecoverableIncomingException) o).getCause());
+    final UnrecoverableIncomingException other = (UnrecoverableIncomingException) o;
+    return o == this
+        || (getCause() == null && other.getCause() == null)
+        || getCause().equals(other.getCause());
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(new Object[] {getCause()});
   }
 }

--- a/mobius-rx3/src/main/java/com/spotify/mobius/rx3/UnrecoverableIncomingException.java
+++ b/mobius-rx3/src/main/java/com/spotify/mobius/rx3/UnrecoverableIncomingException.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.mobius.rx3;
 
+import java.util.Arrays;
+
 /**
  * Used to indicate that an {@link RxMobiusLoop} transformer has received an {@link
  * io.reactivex.rxjava3.core.Observer#onError(Throwable)} call, which is illegal. This exception
@@ -39,6 +41,14 @@ class UnrecoverableIncomingException extends RuntimeException {
       return false;
     }
 
-    return o == this || getCause().equals(((UnrecoverableIncomingException) o).getCause());
+    final UnrecoverableIncomingException other = (UnrecoverableIncomingException) o;
+    return o == this
+        || (getCause() == null && other.getCause() == null)
+        || getCause().equals(other.getCause());
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(new Object[] {getCause()});
   }
 }


### PR DESCRIPTION
The various UnrecoverableIncomingException classes implemented equals() but not hashCode(), which is bad form.