### PR TITLE
Fixing issue with initial Effects sending ViewEffects

### DIFF
--- a/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopViewModel.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopViewModel.java
@@ -116,7 +116,7 @@ public class MobiusLoopViewModel<M, E, F, V> extends ViewModel {
    * @param <F> the effect type
    * @param <V> the view effect type
    */
-  public static <M, E, F, V> MobiusLoopViewModel create(
+  public static <M, E, F, V> MobiusLoopViewModel<M, E, F, V> create(
       @Nonnull Function<Consumer<V>, Factory<M, E, F>> loopFactoryProvider,
       @Nonnull M modelToStartFrom,
       @Nonnull Init<M, F> init,

--- a/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopViewModel.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopViewModel.java
@@ -76,11 +76,11 @@ public class MobiusLoopViewModel<M, E, F, V> extends ViewModel {
       @Nonnull Init<M, F> init,
       @Nonnull WorkRunner mainLoopWorkRunner,
       int maxEffectQueueSize) {
+    viewEffectQueue = new MutableLiveQueue<>(mainLoopWorkRunner, maxEffectQueueSize);
     final Factory<M, E, F> loopFactory = loopFactoryProvider.apply(this::acceptViewEffect);
     final First<M, F> first = init.init(modelToStartFrom);
     loop = loopFactory.startFrom(first.model(), first.effects());
     startModel = first.model();
-    viewEffectQueue = new MutableLiveQueue<>(mainLoopWorkRunner, maxEffectQueueSize);
     loop.observe(this::onModelChanged);
   }
 

--- a/mobius-android/src/main/java/com/spotify/mobius/android/MutableLiveQueue.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MutableLiveQueue.java
@@ -109,9 +109,6 @@ final class MutableLiveQueue<T> implements LiveQueue<T> {
    */
   void post(@Nonnull final T data) {
     synchronized (lock) {
-      if (liveObserver == null) {
-        return;
-      }
       if (lifecycleOwnerIsPaused) {
         if (!pausedEffectsQueue.offer(data)) {
           throw new IllegalStateException(

--- a/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTestUtilClasses.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTestUtilClasses.java
@@ -94,4 +94,30 @@ public class MobiusLoopViewModelTestUtilClasses {
       };
     }
   }
+
+  /** An Effect Handler that simply sends a TestViewEffect to the given view effect consumer. */
+  static class ViewEffectSendingEffectHandler implements Connectable<TestEffect, TestEvent> {
+    private Consumer<TestViewEffect> viewEffectConsumer;
+
+    public ViewEffectSendingEffectHandler(Consumer<TestViewEffect> viewEffectConsumer) {
+      this.viewEffectConsumer = viewEffectConsumer;
+    }
+
+    @Nonnull
+    @Override
+    public Connection<TestEffect> connect(Consumer<TestEvent> output)
+        throws ConnectionLimitExceededException {
+      return new Connection<TestEffect>() {
+        @Override
+        public void accept(TestEffect value) {
+          viewEffectConsumer.accept(new TestViewEffect(value.name));
+        }
+
+        @Override
+        public void dispose() {
+          // do nothing
+        }
+      };
+    }
+  }
 }

--- a/mobius-android/src/test/java/com/spotify/mobius/android/MutableLiveQueueTest.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/MutableLiveQueueTest.java
@@ -89,7 +89,7 @@ public class MutableLiveQueueTest {
   }
 
   @Test
-  public void shouldNotQueueEventsWithNoObserver() {
+  public void shouldQueueEventsWithNoObserver() {
     fakeLifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
 
     mutableLiveQueue.post("one");
@@ -97,7 +97,7 @@ public class MutableLiveQueueTest {
     mutableLiveQueue.setObserver(fakeLifecycleOwner1, liveObserver, pausedObserver);
 
     assertThat(liveObserver.valueCount(), equalTo(0));
-    assertThat(pausedObserver.valueCount(), equalTo(0));
+    assertThat(pausedObserver.valueCount(), equalTo(1));
   }
 
   @Test


### PR DESCRIPTION
Fixed issue that happened when Initial Effects (from the _first_ function) that could immediately send ViewEffects would cause a Null Pointer Exception and ViewEffects would not be forwarded, even though it is expected that it would work.

The fix includes two things:
1. A small change in the order of initiazliation of fields inside the MobiusLoopViewModel
2. A change to MutableLiveQueue so that it will queue up effects to the paused queue when no lifecycle observer is set.

Also introduced a test case to test this scenario.