### PR TITLE
Added a way to filter event sources based on the ViewModel's active state and an internal onCleared method

### DIFF
--- a/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopFactoryProvider.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopFactoryProvider.java
@@ -1,0 +1,45 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.android;
+
+import com.spotify.mobius.MobiusLoop;
+import com.spotify.mobius.functions.Consumer;
+import javax.annotation.Nonnull;
+
+/**
+ * Interface used by the MobiusLoopViewModel to pass all dependencies necessary to create a
+ * MobiusLoop.Factory.
+ */
+public interface MobiusLoopFactoryProvider<M, E, F, V> {
+
+  /**
+   * Creates a MobiusLoop Factory given all the possible dependencies from the MobiusLoopViewModel
+   *
+   * @param viewEffectConsumer The consumer of View Effects that can be used in your Effect Handler
+   * @param activeModelFilter Used to filter EventSources so they only emit while the ViewModel has
+   *     active observers (specifically, while the MobiusLoopViewModel.getModels() has active
+   *     observers - aka observers in a STARTED or RESUMED state)
+   * @return The factory used to create the loop
+   */
+  @Nonnull
+  MobiusLoop.Factory<M, E, F> create(
+      @Nonnull Consumer<V> viewEffectConsumer,
+      @Nonnull ViewModelEventSourceFilter<M> activeModelFilter);
+}

--- a/mobius-android/src/main/java/com/spotify/mobius/android/ViewModelEventSourceFilter.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/ViewModelEventSourceFilter.java
@@ -1,0 +1,61 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.android;
+
+import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
+
+import androidx.lifecycle.LiveData;
+import com.spotify.mobius.EventSource;
+import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.functions.Consumer;
+import javax.annotation.Nonnull;
+
+/** A class that ties to a live data's active state and can then be used to filter event sources. */
+public final class ViewModelEventSourceFilter<M> {
+  private final LiveData<M> liveData;
+
+  ViewModelEventSourceFilter(@Nonnull LiveData<M> liveData) {
+    this.liveData = checkNotNull(liveData);
+  }
+
+  /**
+   * Returns a new EventSource that will only emit events from the original event source while the
+   * underlying LiveData has any active observers.<br>
+   * Events that arrive while there are no observers will be silently discarded.
+   *
+   * @param eventSource The event source to filter
+   * @return A new event source that filters as described.
+   */
+  @Nonnull
+  public <T> EventSource<T> emitWhileModelActive(@Nonnull EventSource<T> eventSource) {
+    return new EventSource<T>() {
+      @Nonnull
+      @Override
+      public Disposable subscribe(Consumer<T> eventConsumer) {
+        return eventSource.subscribe(
+            value -> {
+              if (liveData.hasActiveObservers()) {
+                eventConsumer.accept(value);
+              }
+            });
+      }
+    };
+  }
+}

--- a/mobius-android/src/test/java/com/spotify/mobius/android/EventSourcePublisher.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/EventSourcePublisher.java
@@ -1,0 +1,45 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.android;
+
+import com.spotify.mobius.EventSource;
+import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.functions.Consumer;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import javax.annotation.Nonnull;
+
+class EventSourcePublisher<E> implements EventSource<E> {
+
+  private final List<Consumer<E>> consumers = new CopyOnWriteArrayList<>();
+
+  void publish(E toEmit) {
+    for (Consumer<E> myConsumer : consumers) {
+      myConsumer.accept(toEmit);
+    }
+  }
+
+  @Nonnull
+  @Override
+  public Disposable subscribe(Consumer<E> eventConsumer) {
+    consumers.add(eventConsumer);
+    return () -> consumers.remove(eventConsumer);
+  }
+}

--- a/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTest.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTest.java
@@ -78,7 +78,7 @@ public class MobiusLoopViewModelTest {
     //noinspection Convert2MethodRef
     underTest =
         new MobiusLoopViewModel<>(
-            (Consumer<TestViewEffect> consumer) -> {
+            (Consumer<TestViewEffect> consumer, ViewModelEventSourceFilter<TestModel> filter) -> {
               testViewEffectHandler = new TestViewEffectHandler<>(consumer);
               return Mobius.loop(updateFunction, testViewEffectHandler)
                   .eventRunner(ImmediateWorkRunner::new)
@@ -153,7 +153,7 @@ public class MobiusLoopViewModelTest {
     //noinspection Convert2MethodRef
     underTest =
         new MobiusLoopViewModel<>(
-            (Consumer<TestViewEffect> consumer) -> {
+            (Consumer<TestViewEffect> consumer, ViewModelEventSourceFilter<TestModel> filter) -> {
               Connectable<TestEffect, TestEvent> viewEffectSendingEffectHandler =
                   new ViewEffectSendingEffectHandler(consumer);
               testViewEffectHandler = new TestViewEffectHandler<>(consumer);

--- a/mobius-android/src/test/java/com/spotify/mobius/android/ViewModelEventSourceFilterTest.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/ViewModelEventSourceFilterTest.java
@@ -1,0 +1,104 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.android;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.MutableLiveData;
+import com.spotify.mobius.EventSource;
+import com.spotify.mobius.android.MobiusLoopViewModelTestUtilClasses.TestEvent;
+import com.spotify.mobius.android.MobiusLoopViewModelTestUtilClasses.TestModel;
+import com.spotify.mobius.disposables.Disposable;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ViewModelEventSourceFilterTest {
+  @Rule public InstantTaskExecutorRule rule = new InstantTaskExecutorRule();
+
+  private final MutableLiveData<TestModel> liveData = new MutableLiveData<>(new TestModel("test"));
+  private final FakeLifecycleOwner lifecycleOwner1 = new FakeLifecycleOwner();
+  private final FakeLifecycleOwner lifecycleOwner2 = new FakeLifecycleOwner();
+  private final EventSourcePublisher<TestEvent> originalEventSource = new EventSourcePublisher<>();
+
+  private ViewModelEventSourceFilter<TestModel> underTest =
+      new ViewModelEventSourceFilter<>(liveData);
+
+  @Test
+  public void testFilterDoesNotSendEventsWhenLiveDataHasNoObservers() {
+    final List<TestEvent> receivedEvents = new ArrayList<>(1);
+
+    EventSource<TestEvent> filtered = underTest.emitWhileModelActive(originalEventSource);
+
+    filtered.subscribe(receivedEvents::add);
+    originalEventSource.publish(new TestEvent("test1"));
+
+    assertThat(receivedEvents.size(), equalTo(0));
+  }
+
+  @Test
+  public void testFilterDoesNotSendEventsWhenLiveDataHasInactiveObservers() {
+    final List<TestEvent> receivedEvents = new ArrayList<>(1);
+
+    EventSource<TestEvent> filtered = underTest.emitWhileModelActive(originalEventSource);
+
+    filtered.subscribe(receivedEvents::add);
+    liveData.observe(lifecycleOwner1, testModel -> {});
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    originalEventSource.publish(new TestEvent("test2"));
+
+    assertThat(receivedEvents.size(), equalTo(0));
+  }
+
+  @Test
+  public void testFilterForwardsEventsWhenLiveDataHasAnyActiveObservers() {
+    final List<TestEvent> receivedEvents = new ArrayList<>(1);
+
+    EventSource<TestEvent> filtered = underTest.emitWhileModelActive(originalEventSource);
+
+    filtered.subscribe(receivedEvents::add);
+    liveData.observe(lifecycleOwner1, testModel -> {});
+    liveData.observe(lifecycleOwner2, testModel -> {});
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    originalEventSource.publish(new TestEvent("test3"));
+
+    assertThat(receivedEvents.size(), equalTo(1));
+  }
+
+  @Test
+  public void testFilteredEventConsumerDisposeCallsOriginalConsumerDispose() {
+    final List<TestEvent> receivedEvents = new ArrayList<>(1);
+
+    EventSource<TestEvent> filtered = underTest.emitWhileModelActive(originalEventSource);
+
+    final Disposable disposable = filtered.subscribe(receivedEvents::add);
+    liveData.observe(lifecycleOwner1, testModel -> {});
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    disposable.dispose();
+    originalEventSource.publish(new TestEvent("test4"));
+
+    assertThat(receivedEvents.size(), equalTo(0));
+  }
+}


### PR DESCRIPTION
- Added a protected `onClearedInternal` method in the `MobiusLoopViewModel` that can be overriden and will be called by the `onCleared` method just before the loop is shut down
- Added a new `MobiusLoopViewModel.create` method which, alongside the ViewEffect consumer, provides a `ViewModelEventSourceFilter` tied to the `MobiusLoopViewModel.getModels()` LiveData object
- The `ViewModelEventSourceFilter` can be used to filter `EventSource`s such that they will only emit while underlying LiveData has active observers (aka observers whose lifecycle is in the STARTED or RESUMED state)