### PR TITLE
Added ToggledEventSource and added it to the MobiusLoopViewModel 

### DIFF
--- a/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopFactoryProvider.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MobiusLoopFactoryProvider.java
@@ -1,0 +1,48 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.android;
+
+import com.spotify.mobius.EventSource;
+import com.spotify.mobius.MobiusLoop;
+import com.spotify.mobius.functions.Consumer;
+import javax.annotation.Nonnull;
+
+/**
+ * Interface used by the MobiusLoopViewModel to pass all dependencies necessary to create a
+ * MobiusLoop.Factory.
+ */
+public interface MobiusLoopFactoryProvider<M, E, F, V> {
+
+  /**
+   * Creates a MobiusLoop Factory given all the possible dependencies from the MobiusLoopViewModel
+   *
+   * @param viewEffectConsumer The consumer of View Effects that can be used in your Effect Handler
+   * @param activeModelEventSource An Event Source that emits the current active/inactive state of
+   *     the ViewModel, based on whether or not the ViewModel's {@link
+   *     MobiusLoopViewModel#getModel()} has any active observers or not. This can be used in
+   *     conjuncture with <code>ToggledEventSource</code> to be used to control the emissions of any
+   *     other given Event Source.
+   * @return The factory used to create the loop
+   */
+  @Nonnull
+  MobiusLoop.Factory<M, E, F> create(
+      @Nonnull Consumer<V> viewEffectConsumer,
+      @Nonnull EventSource<Boolean> activeModelEventSource);
+}

--- a/mobius-android/src/main/java/com/spotify/mobius/android/ObservableMutableLiveData.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/ObservableMutableLiveData.java
@@ -1,0 +1,61 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.android;
+
+import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
+
+import androidx.lifecycle.MutableLiveData;
+import com.spotify.mobius.EventSource;
+import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.functions.Consumer;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import javax.annotation.Nonnull;
+
+/** An extension of MutableLiveData that allows its Active/Inactive state to be observed. */
+final class ObservableMutableLiveData<T> extends MutableLiveData<T>
+    implements EventSource<Boolean> {
+  private final List<Consumer<Boolean>> stateListeners = new CopyOnWriteArrayList<>();
+
+  private void notifyListeners(boolean value) {
+    for (Consumer<Boolean> listener : stateListeners) {
+      listener.accept(value);
+    }
+  }
+
+  @Override
+  protected void onActive() {
+    super.onActive();
+    notifyListeners(true);
+  }
+
+  @Override
+  protected void onInactive() {
+    super.onInactive();
+    notifyListeners(false);
+  }
+
+  @Nonnull
+  @Override
+  public Disposable subscribe(Consumer<Boolean> eventConsumer) {
+    stateListeners.add(checkNotNull(eventConsumer));
+    return () -> stateListeners.remove(eventConsumer);
+  }
+}

--- a/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTest.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/MobiusLoopViewModelTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.lifecycle.Lifecycle;
 import com.spotify.mobius.Connectable;
+import com.spotify.mobius.EventSource;
 import com.spotify.mobius.First;
 import com.spotify.mobius.Mobius;
 import com.spotify.mobius.Next;
@@ -78,7 +79,7 @@ public class MobiusLoopViewModelTest {
     //noinspection Convert2MethodRef
     underTest =
         new MobiusLoopViewModel<>(
-            (Consumer<TestViewEffect> consumer) -> {
+            (Consumer<TestViewEffect> consumer, EventSource<Boolean> filter) -> {
               testViewEffectHandler = new TestViewEffectHandler<>(consumer);
               return Mobius.loop(updateFunction, testViewEffectHandler)
                   .eventRunner(ImmediateWorkRunner::new)
@@ -150,10 +151,9 @@ public class MobiusLoopViewModelTest {
 
   @Test
   public void testViewEffectsPostedImmediatelyAreSentCorrectly() {
-    //noinspection Convert2MethodRef
     underTest =
         new MobiusLoopViewModel<>(
-            (Consumer<TestViewEffect> consumer) -> {
+            (Consumer<TestViewEffect> consumer, EventSource<Boolean> filter) -> {
               Connectable<TestEffect, TestEvent> viewEffectSendingEffectHandler =
                   new ViewEffectSendingEffectHandler(consumer);
               testViewEffectHandler = new TestViewEffectHandler<>(consumer);

--- a/mobius-android/src/test/java/com/spotify/mobius/android/ObservableMutableLiveDataTest.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/ObservableMutableLiveDataTest.java
@@ -1,0 +1,100 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.android;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.Lifecycle;
+import com.spotify.mobius.android.MobiusLoopViewModelTestUtilClasses.TestModel;
+import com.spotify.mobius.disposables.Disposable;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ObservableMutableLiveDataTest {
+  @Rule public InstantTaskExecutorRule rule = new InstantTaskExecutorRule();
+
+  private final FakeLifecycleOwner lifecycleOwner1 = new FakeLifecycleOwner();
+
+  private final ObservableMutableLiveData<TestModel> underTest = new ObservableMutableLiveData<>();
+
+  @Test
+  public void testDataSendsInactiveStateOnSubscribeAndThenActiveStateWhenObserverGoesActive() {
+    final List<Boolean> receivedEvents = new ArrayList<>(1);
+
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    underTest.observe(lifecycleOwner1, model -> {});
+    underTest.subscribe(receivedEvents::add);
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+
+    assertThat(receivedEvents.size(), equalTo(1));
+    assertThat(receivedEvents.get(0), equalTo(true));
+  }
+
+  @Test
+  public void testDataSendsActiveStateOnSubscribeAndThenInactiveStateWhenObserverGoesInactive() {
+    final List<Boolean> receivedEvents = new ArrayList<>(1);
+
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    underTest.observe(lifecycleOwner1, model -> {});
+    underTest.subscribe(receivedEvents::add);
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+
+    assertThat(receivedEvents.size(), equalTo(1));
+    assertThat(receivedEvents.get(0), equalTo(false));
+  }
+
+  @Test
+  public void testThatDisposeRemovesObserverFromLiveData() {
+    final List<Boolean> receivedEvents = new ArrayList<>(1);
+
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    underTest.observe(lifecycleOwner1, model -> {});
+    underTest.subscribe(receivedEvents::add).dispose();
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_START);
+
+    assertThat(receivedEvents.size(), equalTo(0));
+  }
+
+  private Disposable d = null;
+
+  @Test
+  public void testThatDisposingFromObserverCallbackDoesNotBreak() {
+    final List<Boolean> receivedEvents = new ArrayList<>(1);
+
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_START);
+    underTest.observe(lifecycleOwner1, model -> {});
+    d =
+        underTest.subscribe(
+            value -> {
+              receivedEvents.add(value);
+              d.dispose();
+            });
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    lifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_START);
+
+    // first emitted event recorded is the ON_STOP, which then immediately disposes
+    assertThat(receivedEvents.size(), equalTo(1));
+    assertThat(receivedEvents.get(0), equalTo(false));
+  }
+}

--- a/mobius-extras/src/main/java/com/spotify/mobius/extras/ToggledEventSource.java
+++ b/mobius-extras/src/main/java/com/spotify/mobius/extras/ToggledEventSource.java
@@ -1,0 +1,172 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras;
+
+import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
+
+import com.spotify.mobius.EventSource;
+import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.functions.Consumer;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An event source that forwards the emitted values of a target Event Source, but whose emissions
+ * are toggled on/off by a secondary Boolean-emitting Event Source
+ *
+ * @param <T> The Event class
+ */
+public final class ToggledEventSource<T> implements EventSource<T> {
+  @Nonnull private final EventSource<T> targetEventSource;
+  @Nonnull private final List<Consumer<T>> consumers = new ArrayList<>(1);
+  @Nullable private Disposable disposable = null;
+  private Boolean active;
+
+  /**
+   * Returns a new EventSource that re-emits events from the <code>targetEventSource</code>
+   * depending on the value emitted by the <code>togglingEventSource</code><br>
+   * When the state is set to not re-emit values, this Event Source unsubscribed from the <code>
+   * targetEventSource</code> completely, and re-subscribes when the state is set to emit values
+   * again.
+   *
+   * @param <E> The class of the events being re-emitted
+   * @param targetEventSource The Event Source whose events will be conditionally re-emitted
+   * @param togglingSource The Event Source whose emitted values control whether the <code>
+   *     targetEventSource</code>'s values are re-emitted (when togglingSource emits True) or
+   *     discarded (when goggling Source emits False)
+   * @param initialToggleState The initial state of whether to re-emit values or not. True to allow
+   *     re-emitting, false to stop it.
+   */
+  @Nonnull
+  public static <E> EventSource<E> from(
+      @Nonnull EventSource<E> targetEventSource,
+      @Nonnull EventSource<Boolean> togglingSource,
+      boolean initialToggleState) {
+    final ToggledEventSource<E> toggledEventSource =
+        new ToggledEventSource<>(targetEventSource, initialToggleState);
+    new ToggledEventSourceWeakReferenceConnection(
+        togglingSource, new WeakReference<>(toggledEventSource));
+    return toggledEventSource;
+  }
+
+  private ToggledEventSource(@Nonnull EventSource<T> targetEventSource, boolean isActive) {
+    this.targetEventSource = checkNotNull(targetEventSource);
+    this.active = isActive;
+  }
+
+  private void setActive(Boolean active) {
+    this.active = active;
+    checkToUpdateSubscription();
+  }
+
+  private void checkToUpdateSubscription() {
+    synchronized (consumers) {
+      if (!active || consumers.size() == 0) {
+        if (disposable != null) {
+          disposable.dispose();
+        }
+        disposable = null;
+      } else {
+        if (disposable == null) {
+          disposable = targetEventSource.subscribe(this::onValueEmitted);
+        }
+      }
+    }
+  }
+
+  private void onValueEmitted(T f) {
+    final List<Consumer<T>> toSendTo;
+    synchronized (consumers) {
+      toSendTo = new ArrayList<>(consumers);
+    }
+    for (Consumer<T> consumer : toSendTo) {
+      consumer.accept(f);
+    }
+  }
+
+  @Nonnull
+  @Override
+  public Disposable subscribe(Consumer<T> eventConsumer) {
+    synchronized (consumers) {
+      consumers.add(eventConsumer);
+      checkToUpdateSubscription();
+    }
+    return new Disposer<>(this, eventConsumer);
+  }
+
+  private void dispose(Consumer<T> eventConsumer) {
+    synchronized (consumers) {
+      consumers.remove(eventConsumer);
+      checkToUpdateSubscription();
+    }
+  }
+
+  private static class Disposer<T> implements Disposable {
+    private ToggledEventSource<T> eventSource;
+    private Consumer<T> eventConsumer;
+
+    private Disposer(ToggledEventSource<T> eventSource, Consumer<T> eventConsumer) {
+
+      this.eventSource = eventSource;
+      this.eventConsumer = eventConsumer;
+    }
+
+    @Override
+    public void dispose() {
+      if (eventSource != null) {
+        eventSource.dispose(eventConsumer);
+        eventSource = null;
+        eventConsumer = null;
+      }
+    }
+  }
+
+  /**
+   * This class observes the given <code>togglingSource</code> and uses its state to set the given
+   * <code>ToggledEventSource</code> as either active (forwarding events) or inactive (not
+   * forwarding events). This class only keeps a Weak Reference to the <code>ToggledEventSource
+   * </code>, and thus will not keep the object alive, and the reference is nulled, this object will
+   * unsubscribe from the <code>togglingSource</code>.
+   */
+  private static class ToggledEventSourceWeakReferenceConnection implements Consumer<Boolean> {
+    private final WeakReference<ToggledEventSource<?>> toggledEventSourceRef;
+    private final Disposable togglingEventSourceDisposable;
+
+    ToggledEventSourceWeakReferenceConnection(
+        EventSource<Boolean> togglingSource,
+        WeakReference<ToggledEventSource<?>> toggledEventSourceWeakReference) {
+      toggledEventSourceRef = toggledEventSourceWeakReference;
+      togglingEventSourceDisposable = togglingSource.subscribe(this);
+    }
+
+    @Override
+    public void accept(Boolean value) {
+      final ToggledEventSource<?> toggledEventSource = toggledEventSourceRef.get();
+      if (toggledEventSource != null) {
+        toggledEventSource.setActive(value);
+      } else {
+        togglingEventSourceDisposable.dispose();
+      }
+    }
+  }
+}

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/FakeDisposingEventSource.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/FakeDisposingEventSource.java
@@ -1,0 +1,52 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.spotify.mobius.EventSource;
+import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.functions.Consumer;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import javax.annotation.Nonnull;
+
+class FakeDisposingEventSource<E> implements EventSource<E> {
+
+  private final List<Consumer<E>> myConsumers = new CopyOnWriteArrayList<>();
+
+  public void assertConsumerCount(int numConsumers) {
+    assertThat(myConsumers.size(), equalTo(numConsumers));
+  }
+
+  void emit(E toEmit) {
+    for (Consumer<E> myConsumer : myConsumers) {
+      myConsumer.accept(toEmit);
+    }
+  }
+
+  @Nonnull
+  @Override
+  public Disposable subscribe(Consumer<E> eventConsumer) {
+    myConsumers.add(eventConsumer);
+    return () -> myConsumers.remove(eventConsumer);
+  }
+}

--- a/mobius-extras/src/test/java/com/spotify/mobius/extras/ToggledEventSourceTest.java
+++ b/mobius-extras/src/test/java/com/spotify/mobius/extras/ToggledEventSourceTest.java
@@ -1,0 +1,160 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.extras;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.spotify.mobius.disposables.Disposable;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ToggledEventSourceTest {
+
+  private FakeDisposingEventSource<String> dataEventSource;
+  private ToggledEventSource<String> underTest;
+  private QueueingEventSubject<Boolean> togglingEventSource;
+
+  @Before
+  public void setUp() {
+    dataEventSource = new FakeDisposingEventSource<>();
+    togglingEventSource = new QueueingEventSubject<>(10);
+    underTest =
+        (ToggledEventSource<String>)
+            ToggledEventSource.from(dataEventSource, togglingEventSource, false);
+  }
+
+  @Test
+  public void testThatActiveEventSourceInitializesWithoutSubscribingToBase() {
+    togglingEventSource.accept(true);
+    dataEventSource.assertConsumerCount(0);
+  }
+
+  @Test
+  public void testActiveEventSourceWithoutSubscribersResubscribesToBaseWhenSubscriberAdded() {
+    togglingEventSource.accept(true);
+    underTest.subscribe(value -> {});
+
+    dataEventSource.assertConsumerCount(1);
+  }
+
+  @Test
+  public void testActiveEventSourceUnsubscribesFromBaseWhenLastSubscriberRemoved() {
+    final List<String> received = new ArrayList<>(1);
+
+    togglingEventSource.accept(true);
+    underTest.subscribe(received::add).dispose();
+
+    dataEventSource.assertConsumerCount(0);
+    assertThat(received).isEmpty();
+  }
+
+  @Test
+  public void testFilterForwardsEventsWhenActive() {
+    final List<String> received = new ArrayList<>(1);
+    togglingEventSource.accept(true);
+    underTest.subscribe(received::add);
+
+    dataEventSource.emit("a");
+
+    dataEventSource.assertConsumerCount(1);
+    assertThat(received).containsExactly("a");
+  }
+
+  @Test
+  public void testToggledEventSourceBlocksEventsAndRemovesConsumersWhenInactive() {
+    final List<String> received = new ArrayList<>(1);
+    togglingEventSource.accept(true);
+    underTest.subscribe(received::add);
+    togglingEventSource.accept(false);
+    dataEventSource.emit("b");
+
+    dataEventSource.assertConsumerCount(0);
+    assertThat(received).isEmpty();
+  }
+
+  @Test
+  public void testToggledEventSourceDisposeRemovesFromSourceEventSource() {
+    final List<String> received = new ArrayList<>(1);
+    togglingEventSource.accept(true);
+    Disposable d = underTest.subscribe(received::add);
+    d.dispose();
+    dataEventSource.emit("c");
+
+    dataEventSource.assertConsumerCount(0);
+    assertThat(received).isEmpty();
+  }
+
+  @Test
+  public void testMultipleSubscribersToToggledAllReceiveForwardedEvents() {
+    final List<String> received1 = new ArrayList<>(1);
+    final List<String> received2 = new ArrayList<>(1);
+
+    underTest.subscribe(received1::add);
+    underTest.subscribe(received2::add);
+    togglingEventSource.accept(true);
+
+    dataEventSource.emit("c3");
+
+    assertThat(received1).containsExactly("c3");
+    assertThat(received2).containsExactly("c3");
+  }
+
+  @Test
+  public void testMultipleSubscribersAndOneDisposesThenEventsAreStillForwardedToTheOther() {
+    final List<String> received1 = new ArrayList<>(1);
+    final List<String> received2 = new ArrayList<>(1);
+
+    underTest.subscribe(received1::add);
+    Disposable d2 = underTest.subscribe(received2::add);
+    togglingEventSource.accept(true);
+
+    dataEventSource.emit("d41");
+
+    d2.dispose();
+
+    dataEventSource.emit("d42");
+
+    dataEventSource.assertConsumerCount(1); // because our event source is still active
+    assertThat(received1).containsExactly("d41", "d42");
+    assertThat(received2).containsExactly("d41");
+  }
+
+  @Test
+  public void testThatToggledEventSourceIsNotKeptAliveByUnderlyingDataSource() {
+    final List<String> received = new ArrayList<>(1);
+
+    WeakReference<ToggledEventSource<String>> referenceCheck = new WeakReference<>(underTest);
+
+    togglingEventSource.accept(true);
+    Disposable d = underTest.subscribe(received::add);
+    dataEventSource.emit("refTest");
+    d.dispose();
+
+    underTest = null;
+    System.gc();
+
+    assertThat(received).containsExactly("refTest");
+    assertThat(underTest).isNull();
+    assertThat(referenceCheck.get()).isNull();
+  }
+}


### PR DESCRIPTION
- Added a protected `onClearedInternal` method in the `MobiusLoopViewModel` that can be overriden and will be called by the onCleared method just before the loop is shut down
- Added an (internal) `ObservableMutableLiveData` class that allows its state (active/inactive) to be observed as a `EventSource<Boolean>
- Added new `MobiusLoopViewModel` creator function that supplies a  `EventSource` that's tied to the ViewModel's `getModels(): LiveData<M>` state (specifically whether it has any active observers or not)
- Added a utility class `ToggledEventSource` which forwards values from a target event source, and can additionally be controlled whether to forward those values from a secondary Boolean-emitting toggling-event-source.


