### PR TITLE
 Simplify RxJava subscribe calls, remove onError

### DIFF
--- a/mobius-rx/build.gradle
+++ b/mobius-rx/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest-library:${versions.hamcrestLibrary}"
     testImplementation "ch.qos.logback:logback-classic:${versions.logback}"
     testImplementation "org.awaitility:awaitility:${versions.awaitility}"
+    testImplementation "org.assertj:assertj-core:${versions.assertjcore}"
     testImplementation "com.google.auto.value:auto-value-annotations:${versions.autoValue}"
 }
 

--- a/mobius-rx/src/test/java/com/spotify/mobius/rx/RxErrorsRule.java
+++ b/mobius-rx/src/test/java/com/spotify/mobius/rx/RxErrorsRule.java
@@ -1,0 +1,50 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.rx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.istack.internal.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import rx.plugins.RxJavaHooks;
+
+/** A rule catching errors by setting an error handler with {@link RxJavaHooks}. */
+public class RxErrorsRule extends TestWatcher {
+
+  private final List<Throwable> mErrors = new ArrayList<>(0);
+
+  @Override
+  protected void starting(@NotNull Description description) {
+    RxJavaHooks.setOnError(mErrors::add);
+  }
+
+  @Override
+  protected void finished(@NotNull Description description) {
+    RxJavaHooks.setOnError(null);
+  }
+
+  public void assertSingleErrorWithMessage(@NotNull String message) {
+    assertThat(mErrors).hasSize(1);
+    assertThat(mErrors.get(0).getMessage()).isEqualTo(message);
+  }
+}

--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxConnectables.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxConnectables.java
@@ -32,7 +32,6 @@ import io.reactivex.ObservableTransformer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Action;
 import io.reactivex.functions.Cancellable;
-import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
 import javax.annotation.Nonnull;
 
@@ -62,18 +61,6 @@ public final class RxConnectables {
                           @Override
                           public void accept(O e) {
                             output.accept(e);
-                          }
-                        },
-                        new io.reactivex.functions.Consumer<Throwable>() {
-                          @Override
-                          public void accept(Throwable throwable) throws Exception {
-                            RxJavaPlugins.onError(throwable);
-                          }
-                        },
-                        new Action() {
-                          @Override
-                          public void run() throws Exception {
-                            // TODO: complain loudly! shouldn't ever complete
                           }
                         });
 

--- a/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxEventSources.java
+++ b/mobius-rx2/src/main/java/com/spotify/mobius/rx2/RxEventSources.java
@@ -27,7 +27,6 @@ import io.reactivex.ObservableEmitter;
 import io.reactivex.ObservableOnSubscribe;
 import io.reactivex.ObservableSource;
 import io.reactivex.functions.Cancellable;
-import io.reactivex.plugins.RxJavaPlugins;
 import javax.annotation.Nonnull;
 
 /**
@@ -61,12 +60,6 @@ public final class RxEventSources {
                   @Override
                   public void accept(E e) throws Exception {
                     eventConsumer.accept(e);
-                  }
-                },
-                new io.reactivex.functions.Consumer<Throwable>() {
-                  @Override
-                  public void accept(Throwable e) throws Exception {
-                    RxJavaPlugins.onError(e);
                   }
                 });
 

--- a/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxErrorsRule.java
+++ b/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxErrorsRule.java
@@ -1,0 +1,50 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.rx2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.istack.internal.NotNull;
+import io.reactivex.plugins.RxJavaPlugins;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+/** A rule catching errors by setting an error handler with {@link RxJavaPlugins}. */
+public class RxErrorsRule extends TestWatcher {
+
+  private final List<Throwable> mErrors = new ArrayList<>(0);
+
+  @Override
+  protected void starting(@NotNull Description description) {
+    RxJavaPlugins.setErrorHandler(mErrors::add);
+  }
+
+  @Override
+  protected void finished(@NotNull Description description) {
+    RxJavaPlugins.setErrorHandler(null);
+  }
+
+  public void assertSingleErrorWithCauseMessage(@NotNull String message) {
+    assertThat(mErrors).hasSize(1);
+    assertThat(mErrors.get(0).getCause().getMessage()).isEqualTo(message);
+  }
+}

--- a/mobius-rx3/src/main/java/com/spotify/mobius/rx3/RxConnectables.java
+++ b/mobius-rx3/src/main/java/com/spotify/mobius/rx3/RxConnectables.java
@@ -33,7 +33,6 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.functions.Action;
 import io.reactivex.rxjava3.functions.Cancellable;
 import io.reactivex.rxjava3.functions.Consumer;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.subjects.PublishSubject;
 import javax.annotation.Nonnull;
 
@@ -63,16 +62,6 @@ public final class RxConnectables {
                       public void accept(O value) throws Throwable {
                         output.accept(value);
                       }
-                    },
-                    new Consumer<Throwable>() {
-                      @Override
-                      public void accept(Throwable error) throws Throwable {
-                        RxJavaPlugins.onError(error);
-                      }
-                    },
-                    new Action() {
-                      @Override
-                      public void run() throws Throwable {}
                     });
 
         return new Connection<I>() {

--- a/mobius-rx3/src/main/java/com/spotify/mobius/rx3/RxEventSources.java
+++ b/mobius-rx3/src/main/java/com/spotify/mobius/rx3/RxEventSources.java
@@ -28,7 +28,6 @@ import io.reactivex.rxjava3.core.ObservableSource;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.functions.Cancellable;
 import io.reactivex.rxjava3.functions.Consumer;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import javax.annotation.Nonnull;
 
 /** RxEventSources. */
@@ -60,12 +59,6 @@ public final class RxEventSources {
                   @Override
                   public void accept(E value) throws Throwable {
                     eventConsumer.accept(value);
-                  }
-                },
-                new Consumer<Throwable>() {
-                  @Override
-                  public void accept(Throwable error) throws Throwable {
-                    RxJavaPlugins.onError(error);
                   }
                 });
         return new com.spotify.mobius.disposables.Disposable() {

--- a/mobius-rx3/src/test/java/com/spotify/mobius/rx3/RxErrorsRule.java
+++ b/mobius-rx3/src/test/java/com/spotify/mobius/rx3/RxErrorsRule.java
@@ -1,0 +1,50 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.mobius.rx3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.istack.internal.NotNull;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+/** A rule catching errors by setting an error handler with {@link RxJavaPlugins}. */
+public class RxErrorsRule extends TestWatcher {
+
+  private final List<Throwable> mErrors = new ArrayList<>(0);
+
+  @Override
+  protected void starting(@NotNull Description description) {
+    RxJavaPlugins.setErrorHandler(mErrors::add);
+  }
+
+  @Override
+  protected void finished(@NotNull Description description) {
+    RxJavaPlugins.setErrorHandler(null);
+  }
+
+  public void assertSingleErrorWithCauseMessage(@NotNull String message) {
+    assertThat(mErrors).hasSize(1);
+    assertThat(mErrors.get(0).getCause().getMessage()).isEqualTo(message);
+  }
+}

--- a/mobius-rx3/src/test/java/com/spotify/mobius/rx3/RxEventSourcesTest.java
+++ b/mobius-rx3/src/test/java/com/spotify/mobius/rx3/RxEventSourcesTest.java
@@ -24,10 +24,14 @@ import com.spotify.mobius.disposables.Disposable;
 import com.spotify.mobius.test.RecordingConsumer;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.subjects.PublishSubject;
+import org.junit.Rule;
 import org.junit.Test;
 
 /** RxEventSourcesTest. */
 public class RxEventSourcesTest {
+
+  @Rule public final RxErrorsRule rxErrorsRule = new RxErrorsRule();
+
   @Test
   public void eventsAreForwardedInOrder() throws Exception {
     EventSource<Integer> source = RxEventSources.fromObservables(Observable.just(1, 2, 3));
@@ -54,5 +58,17 @@ public class RxEventSourcesTest {
 
     consumer.waitForChange(50);
     consumer.assertValues(1, 2);
+  }
+
+  @Test
+  public void errorsAreForwardedToErrorHandler() throws Exception {
+    PublishSubject<Integer> subject = PublishSubject.create();
+    final EventSource<Integer> source = RxEventSources.fromObservables(subject);
+    RecordingConsumer<Integer> consumer = new RecordingConsumer<>();
+
+    source.subscribe(consumer);
+    subject.onError(new RuntimeException("crash!"));
+
+    rxErrorsRule.assertSingleErrorWithCauseMessage("crash!");
   }
 }


### PR DESCRIPTION
From RxJava 2 onwards if `onError()` is not implemented then the default behaviour is that errors are forwarded to RxJavaPlugins so it's not necessary to explicitly do that. The errors will be wrapped differently, but the cause throwable will remain the same.

There's a reason besides aesthetics for doing this: [uber/RxDogTag](https://github.com/uber/RxDogTag), the RxJava stack trace improvement library, only supports observables that do not implement `onError()` handling. It will be easier for us to debug issues when we use the default error handling.

The added tests pass before and after the change.