### PR TITLE
Rx eventsource dispose race

### DIFF
--- a/mobius-rx/src/test/java/com/spotify/mobius/rx/RxEventSourcesTest.java
+++ b/mobius-rx/src/test/java/com/spotify/mobius/rx/RxEventSourcesTest.java
@@ -19,9 +19,18 @@
  */
 package com.spotify.mobius.rx;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.spotify.mobius.EventSource;
 import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.functions.Consumer;
 import com.spotify.mobius.test.RecordingConsumer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Rule;
 import org.junit.Test;
 import rx.Observable;
@@ -69,5 +78,69 @@ public class RxEventSourcesTest {
     subject.onError(new RuntimeException("crash!"));
 
     rxErrorsRule.assertSingleErrorWithMessage("crash!");
+  }
+
+  @Test
+  public void noEventsAreGeneratedAfterDispose() throws InterruptedException, ExecutionException {
+    // given an observable that continuously emits stuff
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    PublishSubject<Integer> subject = PublishSubject.create();
+
+    final AtomicInteger count = new AtomicInteger();
+    final AtomicBoolean stop = new AtomicBoolean();
+
+    Future<?> future =
+        executor.submit(
+            () -> {
+              while (!stop.get()) {
+                subject.onNext(count.incrementAndGet());
+              }
+            });
+
+    // and an event source based on that observable
+    EventSource<Integer> source = RxEventSources.fromObservables(subject);
+
+    // when an event source is subscribed to (many times to make this non-flaky/less flaky)
+    // NOTE: this value is currently set too low for reliable detection - the idea is that there
+    // used to be a bug here, which has now been fixed, so there's no point in running these tests
+    // for too long and slowing down all builds. But running them 'a bit' should hopefully lead to
+    // at least some occasional flakiness, meaning that we'll be able to detect errors sooner or
+    // later, without paying too much for slow tests.
+    for (int i = 1; i < 100; i++) {
+
+      // then, the event consumer doesn't receive events after it has been disposed.
+      EventConsumer consumer = new EventConsumer();
+
+      Disposable disposable = source.subscribe(consumer);
+
+      // the sleep here and below is not strictly necessary, but it helps provoke errors more
+      // frequently (on my laptop at least..). YMMV in case there is another issue like this one
+      // in the future.
+      Thread.sleep(1);
+
+      disposable.dispose();
+      consumer.disposed = true;
+
+      Thread.sleep(3);
+
+      assertThat(consumer.acceptCalledAfterDispose)
+          .describedAs("accept called after dispose on attempt %d", i)
+          .isFalse();
+    }
+
+    stop.set(true);
+    future.get();
+  }
+
+  private static class EventConsumer implements Consumer<Integer> {
+    public volatile boolean disposed = false;
+    public volatile boolean acceptCalledAfterDispose = false;
+
+    @Override
+    public void accept(Integer value) {
+      if (disposed) {
+        acceptCalledAfterDispose = true;
+      }
+    }
   }
 }

--- a/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxEventSourcesTest.java
+++ b/mobius-rx2/src/test/java/com/spotify/mobius/rx2/RxEventSourcesTest.java
@@ -19,11 +19,20 @@
  */
 package com.spotify.mobius.rx2;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.spotify.mobius.EventSource;
 import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.functions.Consumer;
 import com.spotify.mobius.test.RecordingConsumer;
 import io.reactivex.Observable;
 import io.reactivex.subjects.PublishSubject;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -69,5 +78,69 @@ public class RxEventSourcesTest {
     subject.onError(new RuntimeException("crash!"));
 
     rxErrorsRule.assertSingleErrorWithCauseMessage("crash!");
+  }
+
+  @Test
+  public void noEventsAreGeneratedAfterDispose() throws InterruptedException, ExecutionException {
+    // given an observable that continuously emits stuff
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    PublishSubject<Integer> subject = PublishSubject.create();
+
+    final AtomicInteger count = new AtomicInteger();
+    final AtomicBoolean stop = new AtomicBoolean();
+
+    Future<?> future =
+        executor.submit(
+            () -> {
+              while (!stop.get()) {
+                subject.onNext(count.incrementAndGet());
+              }
+            });
+
+    // and an event source based on that observable
+    EventSource<Integer> source = RxEventSources.fromObservables(subject);
+
+    // when an event source is subscribed to (many times to make this non-flaky/less flaky)
+    // NOTE: this value is currently set too low for reliable detection - the idea is that there
+    // used to be a bug here, which has now been fixed, so there's no point in running these tests
+    // for too long and slowing down all builds. But running them 'a bit' should hopefully lead to
+    // at least some occasional flakiness, meaning that we'll be able to detect errors sooner or
+    // later, without paying too much for slow tests.
+    for (int i = 1; i < 100; i++) {
+
+      // then, the event consumer doesn't receive events after it has been disposed.
+      EventConsumer consumer = new EventConsumer();
+
+      Disposable disposable = source.subscribe(consumer);
+
+      // the sleep here and below is not strictly necessary, but it helps provoke errors more
+      // frequently (on my laptop at least..). YMMV in case there is another issue like this one
+      // in the future.
+      Thread.sleep(1);
+
+      disposable.dispose();
+      consumer.disposed = true;
+
+      Thread.sleep(3);
+
+      assertThat(consumer.acceptCalledAfterDispose)
+          .describedAs("accept called after dispose on attempt %d", i)
+          .isFalse();
+    }
+
+    stop.set(true);
+    future.get();
+  }
+
+  private static class EventConsumer implements Consumer<Integer> {
+    public volatile boolean disposed = false;
+    public volatile boolean acceptCalledAfterDispose = false;
+
+    @Override
+    public void accept(Integer value) {
+      if (disposed) {
+        acceptCalledAfterDispose = true;
+      }
+    }
   }
 }

--- a/mobius-rx3/src/test/java/com/spotify/mobius/rx3/RxEventSourcesTest.java
+++ b/mobius-rx3/src/test/java/com/spotify/mobius/rx3/RxEventSourcesTest.java
@@ -19,11 +19,20 @@
  */
 package com.spotify.mobius.rx3;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.spotify.mobius.EventSource;
 import com.spotify.mobius.disposables.Disposable;
+import com.spotify.mobius.functions.Consumer;
 import com.spotify.mobius.test.RecordingConsumer;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.subjects.PublishSubject;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -70,5 +79,69 @@ public class RxEventSourcesTest {
     subject.onError(new RuntimeException("crash!"));
 
     rxErrorsRule.assertSingleErrorWithCauseMessage("crash!");
+  }
+
+  @Test
+  public void noEventsAreGeneratedAfterDispose() throws InterruptedException, ExecutionException {
+    // given an observable that continuously emits stuff
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    PublishSubject<Integer> subject = PublishSubject.create();
+
+    final AtomicInteger count = new AtomicInteger();
+    final AtomicBoolean stop = new AtomicBoolean();
+
+    Future<?> future =
+        executor.submit(
+            () -> {
+              while (!stop.get()) {
+                subject.onNext(count.incrementAndGet());
+              }
+            });
+
+    // and an event source based on that observable
+    EventSource<Integer> source = RxEventSources.fromObservables(subject);
+
+    // when an event source is subscribed to (many times to make this non-flaky/less flaky)
+    // NOTE: this value is currently set too low for reliable detection - the idea is that there
+    // used to be a bug here, which has now been fixed, so there's no point in running these tests
+    // for too long and slowing down all builds. But running them 'a bit' should hopefully lead to
+    // at least some occasional flakiness, meaning that we'll be able to detect errors sooner or
+    // later, without paying too much for slow tests.
+    for (int i = 1; i < 100; i++) {
+
+      // then, the event consumer doesn't receive events after it has been disposed.
+      EventConsumer consumer = new EventConsumer();
+
+      Disposable disposable = source.subscribe(consumer);
+
+      // the sleep here and below is not strictly necessary, but it helps provoke errors more
+      // frequently (on my laptop at least..). YMMV in case there is another issue like this one
+      // in the future.
+      Thread.sleep(1);
+
+      disposable.dispose();
+      consumer.disposed = true;
+
+      Thread.sleep(3);
+
+      assertThat(consumer.acceptCalledAfterDispose)
+          .describedAs("accept called after dispose on attempt %d", i)
+          .isFalse();
+    }
+
+    stop.set(true);
+    future.get();
+  }
+
+  private static class EventConsumer implements Consumer<Integer> {
+    public volatile boolean disposed = false;
+    public volatile boolean acceptCalledAfterDispose = false;
+
+    @Override
+    public void accept(Integer value) {
+      if (disposed) {
+        acceptCalledAfterDispose = true;
+      }
+    }
   }
 }


### PR DESCRIPTION
Mobius requires a guarantee that once `dispose` has completed, `accept` will not be invoked. This guarantee is not provided by RxJava, so this PR ensures that it holds for EventSources based on RxJava Observables. 