### PR TITLE
Remove Travis CI build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![Mobius Logo](/docs/assets/images/mobius-logo.png)
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.spotify.mobius/mobius-core.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.spotify.mobius%22)
-[![Build Status](https://travis-ci.org/spotify/mobius.svg?branch=master)](https://travis-ci.org/spotify/mobius)
 [![Code Coverage](https://codecov.io/gh/spotify/mobius/branch/master/graph/badge.svg)](https://codecov.io/gh/spotify/mobius)
 [![License](https://img.shields.io/github/license/spotify/mobius.svg)](LICENSE)
 [![Join the chat at https://gitter.im/spotify/mobius](https://badges.gitter.im/spotify/mobius.svg)](https://gitter.im/spotify/mobius)


### PR DESCRIPTION
Remove Travis CI build badge because this project is not built on there anymore.