### PR TITLE
Add LiveQueue method to enable ignoring of paused effects entirely

### DIFF
--- a/mobius-android/src/main/java/com/spotify/mobius/android/LiveQueue.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/LiveQueue.java
@@ -53,6 +53,16 @@ public interface LiveQueue<T> {
       @Nonnull LifecycleOwner lifecycleOwner, @Nonnull Observer<T> liveEffectsObserver);
 
   /**
+   * A utility method for calling {@link #setObserver(LifecycleOwner, Observer, Observer)} that
+   * substitutes null for the optional observer. This method will also cause any effects that occur
+   * in background to be ignored, and they will not besent if a new pausedEffectsObserver is added.
+   * The paused effects will not be added in a queue at all, so there will be no exceptions thrown
+   * due to queue size exceeding a limit.
+   */
+  void setObserverIgnoringPausedEffects(
+      @Nonnull LifecycleOwner lifecycleOwner, @Nonnull Observer<T> liveEffectsObserver);
+
+  /**
    * The <code>LiveQueue</code> supports only a single observer, so calling this method will
    * override any previous observers set.<br>
    * Effects while the lifecycle is active are sent only to the liveEffectsObserver.<br>

--- a/mobius-android/src/main/java/com/spotify/mobius/android/MutableLiveQueue.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MutableLiveQueue.java
@@ -55,6 +55,7 @@ final class MutableLiveQueue<T> implements LiveQueue<T> {
   @Nullable private Observer<T> liveObserver = null;
   @Nullable private Observer<Iterable<T>> pausedObserver = null;
   private boolean lifecycleOwnerIsPaused = true;
+  private boolean ignoreBackgroundEffects = false;
 
   MutableLiveQueue(WorkRunner effectsWorkRunner, int capacity) {
     this.effectsWorkRunner = effectsWorkRunner;
@@ -77,6 +78,15 @@ final class MutableLiveQueue<T> implements LiveQueue<T> {
   }
 
   @Override
+  public void setObserverIgnoringPausedEffects(
+      @Nonnull LifecycleOwner owner, @Nonnull Observer<T> liveEffectsObserver) {
+    synchronized (lock) {
+      setObserver(owner, liveEffectsObserver, null);
+      ignoreBackgroundEffects = true;
+    }
+  }
+
+  @Override
   public void setObserver(
       @Nonnull LifecycleOwner lifecycleOwner,
       @Nonnull Observer<T> liveObserver,
@@ -89,6 +99,7 @@ final class MutableLiveQueue<T> implements LiveQueue<T> {
       this.pausedObserver = pausedObserver;
       this.lifecycleOwnerIsPaused = true;
       lifecycleOwner.getLifecycle().addObserver(new LifecycleObserverHelper());
+      ignoreBackgroundEffects = false;
     }
   }
 
@@ -110,7 +121,7 @@ final class MutableLiveQueue<T> implements LiveQueue<T> {
   void post(@Nonnull final T data) {
     synchronized (lock) {
       if (lifecycleOwnerIsPaused) {
-        if (!pausedEffectsQueue.offer(data)) {
+        if (shouldQueuePausedEffects() && !pausedEffectsQueue.offer(data)) {
           throw new IllegalStateException(
               "Maximum effect queue size ("
                   + pausedEffectsQueue.size()
@@ -121,6 +132,10 @@ final class MutableLiveQueue<T> implements LiveQueue<T> {
         effectsWorkRunner.post(() -> sendToLiveObserver(data));
       }
     }
+  }
+
+  private boolean shouldQueuePausedEffects() {
+    return !ignoreBackgroundEffects;
   }
 
   private void onLifecycleChanged(Lifecycle.Event event) {

--- a/mobius-android/src/main/java/com/spotify/mobius/android/MutableLiveQueue.java
+++ b/mobius-android/src/main/java/com/spotify/mobius/android/MutableLiveQueue.java
@@ -83,6 +83,7 @@ final class MutableLiveQueue<T> implements LiveQueue<T> {
     synchronized (lock) {
       setObserver(owner, liveEffectsObserver, null);
       ignoreBackgroundEffects = true;
+      pausedEffectsQueue.clear();
     }
   }
 

--- a/mobius-android/src/test/java/com/spotify/mobius/android/MutableLiveQueueTest.java
+++ b/mobius-android/src/test/java/com/spotify/mobius/android/MutableLiveQueueTest.java
@@ -101,6 +101,19 @@ public class MutableLiveQueueTest {
   }
 
   @Test
+  public void shouldNotQueueEventsWhenSetToIgnoreBackgroundEventsAndNoObserver() {
+    mutableLiveQueue.setObserverIgnoringPausedEffects(fakeLifecycleOwner1, liveObserver);
+    fakeLifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
+    mutableLiveQueue.post("one");
+    mutableLiveQueue.post("two");
+    mutableLiveQueue.setObserver(fakeLifecycleOwner1, liveObserver, pausedObserver);
+    fakeLifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+
+    assertThat(liveObserver.valueCount(), equalTo(0));
+    assertThat(pausedObserver.valueCount(), equalTo(0));
+  }
+
+  @Test
   public void shouldSendQueuedEventsWithValidPausedObserver() {
     fakeLifecycleOwner1.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
 


### PR DESCRIPTION
This adds another way to set observers on a `LiveQueue` such that all paused (aka background) effects are completely ignored.

The main reason for this was a use case encountered where the developers do not care to listen to background effects (no paused listener was set) - but a crash was still happening due to the background queue size potentially exceeding the set limit. 

This PR provides a way to completely ignore background effects without ever having to worry about the queue size exceeding size limits, while preserving all previous behavior.