### PR TITLE
Add Coroutines utilities to use alongside Mobius

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.13.0"
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20'
     }
 }
 
@@ -54,6 +55,7 @@ ext {
             'androidXCoreTesting' : '2.1.0',
             'errorProne'          : '2.4.0',
             'errorProneJavac'     : '9+181-r4173-1',
+            'kotlinxCoroutines'  : '1.7.3',
     ]
 }
 

--- a/mobius-coroutines/build.gradle
+++ b/mobius-coroutines/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'java-library'
+}
+
+dependencies {
+    api project(':mobius-core')
+
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinxCoroutines}"
+
+    testImplementation project(':mobius-test')
+    testImplementation "junit:junit:${versions.junit}"
+    testImplementation 'app.cash.turbine:turbine:1.0.0'
+    testImplementation 'com.google.truth:truth:1.1.5'
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinxCoroutines}"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+compileJava {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+test {
+    testLogging {
+        events "skipped", "failed"
+        exceptionFormat "full"
+    }
+}
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+apply from: rootProject.file('gradle/jacoco-coverage.gradle')
+

--- a/mobius-coroutines/gradle.properties
+++ b/mobius-coroutines/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=mobius-coroutines
+POM_NAME=Kotlin Coroutines tools for Mobius
+POM_DESCRIPTION=Kotlin Coroutines utilities for use with Mobius

--- a/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/CoroutinesSubtypeEffectHandlerBuilder.kt
+++ b/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/CoroutinesSubtypeEffectHandlerBuilder.kt
@@ -1,0 +1,83 @@
+package com.spotify.mobius.coroutines
+
+import com.spotify.mobius.Connectable
+import com.spotify.mobius.Connection
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlin.coroutines.CoroutineContext
+import kotlin.reflect.KClass
+
+/**
+ * Builder for a type-routing effect handler.
+ *
+ * <p>Register handlers for different subtypes of F using the add(...) methods, and call [build]
+ * to create an instance of the effect handler. You can then create a loop with the
+ * router as the effect handler using [com.spotify.mobius.Mobius.loop].
+ *
+ * <p>The handler will look at the type of each incoming effect object and try to find a
+ * registered handler for that particular subtype of F. If a handler is found, it will be given
+ * the effect object, otherwise an exception will be thrown.
+ *
+ * <p>All the classes that the effect router know about must have a common type F. Note that
+ * instances of the builder are mutable and not thread-safe.
+ */
+class CoroutinesSubtypeEffectHandlerBuilder<F : Any, E : Any> {
+    private val effectHandlersMap = mutableMapOf<KClass<out F>, suspend (F) -> Flow<E>>()
+
+    inline fun <reified G : F> addAction(
+        crossinline action: suspend () -> Unit
+    ) = addFlowProducer<G> {
+        action.invoke()
+        flowOf()
+    }
+
+    inline fun <reified G : F> addConsumer(
+        crossinline consumer: suspend (G) -> Unit
+    ) = addFlowProducer<G> { effect ->
+        consumer.invoke(effect)
+        flowOf()
+    }
+
+    inline fun <reified G : F> addFunction(
+        crossinline function: suspend (G) -> E
+    ): CoroutinesSubtypeEffectHandlerBuilder<F, E> = addFlowProducer<G> { effect ->
+        val event = function.invoke(effect)
+        flowOf(event)
+    }
+
+    inline fun <reified G : F> addFlowProducer(
+        crossinline function: suspend (G) -> Flow<E>
+    ): CoroutinesSubtypeEffectHandlerBuilder<F, E> {
+        addEffectHandler(G::class) { effect ->
+            function.invoke(effect as G)
+        }
+        return this
+    }
+
+    fun addEffectHandler(kClass: KClass<out F>, function: suspend (F) -> Flow<E>) {
+        val previousValue = effectHandlersMap.put(kClass, function)
+        if (previousValue != null) error("Trying to add more than one handler for the effect ${kClass.simpleName}")
+    }
+
+    fun build(coroutineContext: CoroutineContext) = build(CoroutineScope(coroutineContext))
+
+    private fun build(scope: CoroutineScope) = Connectable { eventConsumer ->
+        object : Connection<F> {
+            override fun accept(effect: F) {
+                scope.launch {
+                    if (scope.isActive) {
+                        val effectHandler = effectHandlersMap[effect::class] ?: error("No effectHandler for $effect")
+                        effectHandler.invoke(effect).collect {
+                            if (scope.isActive) eventConsumer.accept(it)
+                        }
+                    }
+                }
+            }
+
+            override fun dispose() {
+                scope.cancel(CancellationException("Effect Handler disposed"))
+            }
+        }
+    }
+}

--- a/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/DispatcherWorker.kt
+++ b/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/DispatcherWorker.kt
@@ -1,0 +1,24 @@
+package com.spotify.mobius.coroutines
+
+import com.spotify.mobius.runners.WorkRunner
+import java.util.concurrent.CancellationException
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/** A [WorkRunner] that is backed by a [CoroutineContext] for running work. */
+class DispatcherWorker(coroutineContext: CoroutineContext) : WorkRunner {
+    private val scope = CoroutineScope(coroutineContext)
+
+    override fun post(task: Runnable) {
+        scope.launch {
+            if (scope.isActive) task.run()
+        }
+    }
+
+    override fun dispose() {
+        scope.cancel(CancellationException("DispatcherWorker disposed"))
+    }
+}

--- a/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/FlowEventSources.kt
+++ b/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/FlowEventSources.kt
@@ -1,0 +1,63 @@
+package com.spotify.mobius.coroutines
+
+import com.spotify.mobius.EventSource
+import com.spotify.mobius.disposables.Disposable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.launch
+import java.util.concurrent.CancellationException
+import kotlin.coroutines.CoroutineContext
+
+/** Contains utility methods for converting back and forth between [Flow]s and [EventSource]s. */
+interface FlowEventSources {
+    companion object {
+
+        /**
+         * Creates an [EventSource] from the given [Flow]s.
+         *
+         * <p>All streams must be mapped to your event type.
+         *
+         * @param coroutineContext the context where the flows will run.
+         * @param flows the [Flow]s you want to include in the returned [EventSource].
+         * @param <E> the event type.
+         *
+         * @return an [EventSource] based on the provided [Flow]s
+         */
+        fun <E : Any> fromFlows(coroutineContext: CoroutineContext = Dispatchers.Default, vararg flows: Flow<E>) =
+            EventSource { consumer ->
+                val scope = CoroutineScope(coroutineContext)
+
+                scope.launch {
+                    flows.asIterable().merge().collect { consumer.accept(it) }
+                }
+
+                Disposable { scope.cancel(CancellationException("EventSource disposed")) }
+            }
+
+        /**
+         * Creates a [Flow] from the given [EventSource].
+         *
+         * @receiver the [EventSource] you want to convert to a [Flow]
+         * @param <E> the event type
+         * @return a [Flow] based on the provided [EventSource]
+         */
+        fun <E : Any> EventSource<E>.asFlow() = callbackFlow<E> {
+            val disposable = this@asFlow.subscribe { event ->
+                trySendBlocking(event)
+                    .onFailure { exception ->
+                        if (exception != null && exception !is InterruptedException) throw exception
+                    }
+            }
+            awaitClose {
+                disposable.dispose()
+            }
+        }
+    }
+}

--- a/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/MobiusCoroutines.kt
+++ b/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/MobiusCoroutines.kt
@@ -1,0 +1,32 @@
+package com.spotify.mobius.coroutines
+
+import com.spotify.mobius.MobiusLoop
+import kotlin.coroutines.CoroutineContext
+
+/** Factory methods for wrapping Mobius core classes in coroutines transformers. */
+interface MobiusCoroutines {
+
+    companion object {
+        /**
+         * Create a [CoroutinesSubtypeEffectHandlerBuilder] for handling effects based on their type.
+         *
+         * @param <F> the effect type
+         * @param <E> the event type
+         */
+        fun <F : Any, E : Any> subtypeEffectHandler() = CoroutinesSubtypeEffectHandlerBuilder<F, E>()
+
+        /**
+         * Returns a new [MobiusLoop.Builder] with a [DispatcherWorker] using the supplied [CoroutineContext]
+         * as effect runner, and the same values as the current one for the other fields.
+         */
+        fun <M, E, F> MobiusLoop.Builder<M, E, F>.effectRunner(coroutineContext: CoroutineContext) =
+            effectRunner { DispatcherWorker(coroutineContext) }
+
+        /**
+         * Returns a new [MobiusLoop.Builder] with a [DispatcherWorker] using the supplied [CoroutineContext]
+         * as event runner, and the same values as the current one for the other fields.
+         */
+        fun <M, E, F> MobiusLoop.Builder<M, E, F>.eventRunner(coroutineContext: CoroutineContext) =
+            eventRunner { DispatcherWorker(coroutineContext) }
+    }
+}

--- a/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/CoroutinesSubtypeEffectHandlerBuilderTest.kt
+++ b/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/CoroutinesSubtypeEffectHandlerBuilderTest.kt
@@ -1,0 +1,208 @@
+package com.spotify.mobius.coroutines
+
+import com.google.common.truth.Truth.assertThat
+import com.spotify.mobius.coroutines.MobiusCoroutines.Companion.subtypeEffectHandler
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class CoroutinesSubtypeEffectHandlerBuilderTest {
+
+    @Test
+    @Requirement(
+        given = "A CoroutinesSubtypeEffectHandlerBuilder",
+        `when` = "two effect handlers are added for the same effect",
+        then = "an exception is thrown"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun duplicateEffectHandler() {
+        assertThrows(RuntimeException::class.java) {
+            subtypeEffectHandler<Effect, Event>()
+                .addAction<Effect.Simple> { }
+                .addConsumer<Effect.Simple> { }
+        }
+    }
+
+    @Test
+    @Requirement(
+        given = "A connectable without any effect handlers",
+        `when` = "an effect is produced",
+        then = "an exception is thrown"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun emptyEffectHandler() {
+        assertThrows(RuntimeException::class.java) {
+            runTest {
+                val effectHandler = subtypeEffectHandler<Effect, Event>()
+
+                effectHandler.build(coroutineContext)
+                    .connect { }
+                    .accept(Effect.Simple)
+                advanceUntilIdle()
+            }
+        }
+    }
+
+    @Test
+    @Requirement(
+        given = "An action as effect handler",
+        `when` = "a matching effect is produced",
+        then = "the effect is consumed successfully"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun actionEffectHandler() = runTest {
+        var actionCalled = false
+        val effectHandler = subtypeEffectHandler<Effect, Event>()
+            .addAction<Effect.Simple> { actionCalled = true }
+
+        effectHandler.build(coroutineContext)
+            .connect { }
+            .accept(Effect.Simple)
+        advanceUntilIdle()
+
+        assertThat(actionCalled).isTrue()
+    }
+
+    @Test
+    @Requirement(
+        given = "An effect handler failing with an exception",
+        `when` = "a matching effect is produced",
+        then = "the exception is propagated"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun actionEffectHandlerError() {
+        val effectHandler = subtypeEffectHandler<Effect, Event>()
+            .addAction<Effect.Simple> { error("Error in Action") }
+
+        assertThrows(RuntimeException::class.java) {
+            runTest {
+                effectHandler.build(coroutineContext)
+                    .connect { }
+                    .accept(Effect.Simple)
+                advanceUntilIdle()
+            }
+        }
+    }
+
+    @Test
+    @Requirement(
+        given = "A connectable with a consumer as effect handler",
+        `when` = "a matching effect is produced",
+        then = "the effect is consumed successfully"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun consumerEffectHandler() = runTest {
+        var effectConsumed: Effect? = null
+        val effectHandler = subtypeEffectHandler<Effect, Event>()
+            .addConsumer<Effect.SingleValue> { effectConsumed = it }
+
+        effectHandler.build(coroutineContext)
+            .connect { }
+            .accept(Effect.SingleValue("Effect to consume"))
+        advanceUntilIdle()
+
+        assertThat(effectConsumed).isEqualTo(Effect.SingleValue("Effect to consume"))
+    }
+
+    @Test
+    @Requirement(
+        given = "A connectable with a function as effect handler",
+        `when` = "a matching effect is produced",
+        then = "the effect is consumed successfully " +
+                "AND the produced event is propagated"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun functionEffectHandler() = runTest {
+        var eventProduced: Event? = null
+        var effectConsumed: Effect? = null
+        val effectHandler = subtypeEffectHandler<Effect, Event>()
+            .addFunction<Effect.SingleValue> {
+                effectConsumed = it
+                Event.SingleValue("Produced event")
+            }
+
+        effectHandler.build(coroutineContext)
+            .connect { eventProduced = it }
+            .accept(Effect.SingleValue("Effect to produce event"))
+        advanceUntilIdle()
+
+        assertThat(effectConsumed).isEqualTo(Effect.SingleValue("Effect to produce event"))
+        assertThat(eventProduced).isEqualTo(Event.SingleValue("Produced event"))
+    }
+
+    @Test
+    @Requirement(
+        given = "A connectable with a flow producer as effect handler",
+        `when` = "a matching effect is produced",
+        then = "the effect is consumed successfully " +
+                "AND all the produced events are propagated"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun flowProducerEffectHandler() = runTest {
+        val eventsProduced = mutableListOf<Event>()
+        var effectConsumed: Effect? = null
+        val effectHandler = subtypeEffectHandler<Effect, Event>()
+            .addFlowProducer<Effect.ValueList> { effect ->
+                effectConsumed = effect
+                flow {
+                    effect.tokens.forEach { token -> emit(Event.SingleValue(token)) }
+                }
+            }
+
+        effectHandler.build(coroutineContext)
+            .connect { eventsProduced.add(it) }
+            .accept(Effect.ValueList(listOf("token1", "token2", "token3")))
+        advanceUntilIdle()
+
+        assertThat(effectConsumed).isEqualTo(Effect.ValueList(listOf("token1", "token2", "token3")))
+        assertThat(eventsProduced).containsExactly(
+            Event.SingleValue("token1"),
+            Event.SingleValue("token2"),
+            Event.SingleValue("token3"),
+        )
+    }
+
+    @Test
+    @Requirement(
+        given = "An effect handler",
+        `when` = "the effect handler is disposed",
+        then = "all running task are cancelled"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun disposeEffectHandler() = runTest {
+        var effectStarted = false
+        var effectFinished = false
+        val effectHandler = subtypeEffectHandler<Effect, Event>()
+            .addAction<Effect.Simple> {
+                effectStarted = true
+                delay(1000)
+                effectFinished = true
+            }
+
+        val connection = effectHandler.build(StandardTestDispatcher(testScheduler) + Job())
+            .connect { }
+        connection.accept(Effect.Simple)
+        advanceTimeBy(500)
+        connection.dispose()
+        advanceUntilIdle()
+
+        assertThat(effectStarted).isTrue()
+        assertThat(effectFinished).isFalse()
+    }
+
+    private sealed interface Effect {
+        data object Simple : Effect
+        data class SingleValue(val id: String) : Effect
+        data class ValueList(val tokens: List<String>) : Effect
+    }
+
+    private sealed interface Event {
+        data class SingleValue(val id: String) : Event
+    }
+}

--- a/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/DispatcherWorkerTest.kt
+++ b/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/DispatcherWorkerTest.kt
@@ -1,0 +1,100 @@
+package com.spotify.mobius.coroutines
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class DispatcherWorkerTest {
+
+    @Test
+    @Requirement(
+        given = "Dispatcher worker",
+        `when` = "a work is post",
+        then = "the work is processed"
+    )
+    @ExperimentalCoroutinesApi
+    fun postedWorkIsProcessed() = runTest {
+        val worker = DispatcherWorker(coroutineContext)
+        var taskProcessed = false
+
+        worker.post { taskProcessed = true }
+        advanceUntilIdle()
+
+        assertThat(taskProcessed).isTrue()
+    }
+
+    @Test
+    @Requirement(
+        given = "Dispatcher worker",
+        `when` = "a work is post throwing an exception",
+        then = "the exception is propagated"
+    )
+    @ExperimentalCoroutinesApi
+    fun exceptionsArePropagated() {
+        assertThrows("Exception in work", RuntimeException::class.java) {
+            runTest {
+                val worker = DispatcherWorker(coroutineContext)
+
+                worker.post { error("Exception in work") }
+                advanceUntilIdle()
+            }
+        }
+    }
+
+    @Test
+    @Requirement(
+        given = "Dispatcher worker",
+        `when` = "worker is disposed while a work is running",
+        then = "the work is cancelled"
+    )
+    @ExperimentalCoroutinesApi
+    fun workIsCancelled() = runTest {
+        var workStarted = false
+        var workFinished = false
+
+        val job = Job()
+        val context = StandardTestDispatcher(testScheduler) + job
+        val worker = DispatcherWorker(context)
+
+        worker.post {
+            launch(context) {
+                workStarted = true
+                delay(2000)
+                workFinished = true
+            }
+        }
+
+        runCurrent()
+        worker.dispose()
+        advanceUntilIdle()
+
+        assertThat(workStarted).isTrue()
+        assertThat(workFinished).isFalse()
+    }
+
+    @Test
+    @Requirement(
+        given = "Dispatcher worker that has been disposed",
+        `when` = "a work is post",
+        then = "the work is not processed"
+    )
+    @ExperimentalCoroutinesApi
+    fun workOnDisposedWorker() = runTest {
+        var workStarted = false
+        val worker = DispatcherWorker(StandardTestDispatcher(testScheduler))
+
+        worker.dispose()
+        worker.post { workStarted = true }
+        advanceUntilIdle()
+
+        assertThat(workStarted).isFalse()
+    }
+}

--- a/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/FlowEventSourcesTest.kt
+++ b/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/FlowEventSourcesTest.kt
@@ -1,0 +1,195 @@
+package com.spotify.mobius.coroutines
+
+import com.google.common.truth.Truth.assertThat
+import com.spotify.mobius.EventSource
+import com.spotify.mobius.coroutines.FlowEventSources.Companion.asFlow
+import com.spotify.mobius.disposables.Disposable
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class FlowEventSourcesTest {
+
+    @Test
+    @Requirement(
+        given = "Event source from flows",
+        `when` = "a flow produces an event",
+        then = "the event is notified"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun eventIsNotified() = runTest {
+        val eventsReceived = mutableListOf<Event>()
+        val eventSource = FlowEventSources.fromFlows(
+            coroutineContext,
+            flowOf(Event("event1"))
+        )
+
+        eventSource.subscribe { eventsReceived.add(it) }
+        advanceUntilIdle()
+
+        assertThat(eventsReceived).containsExactly(Event("event1"))
+    }
+
+    @Test
+    @Requirement(
+        given = "Event source from flows",
+        `when` = "a flow produces an event after subscribe",
+        then = "the event is notified"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun eventIsNotifiedAfterSubscribe() = runTest {
+        val eventsReceived = mutableListOf<Event>()
+        val eventSource = FlowEventSources.fromFlows<Event>(
+            coroutineContext,
+            flow {
+                delay(2000)
+                emit(Event("delayed"))
+            }
+        )
+
+        eventSource.subscribe { eventsReceived.add(it) }
+        advanceTimeBy(1500)
+        assertThat(eventsReceived).isEmpty()
+
+        advanceUntilIdle()
+        assertThat(eventsReceived).containsExactly(Event("delayed"))
+    }
+
+    @Test
+    @Requirement(
+        given = "Event source from 2 flows",
+        `when` = "any flow produces an event",
+        then = "the event is notified immediately"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun multipleFlows() = runTest {
+        val eventsReceived = mutableListOf<Event>()
+        val eventSource = FlowEventSources.fromFlows<Event>(
+            coroutineContext,
+            flow {
+                delay(500)
+                emit(Event("delayed 500"))
+            },
+            flow {
+                delay(2000)
+                emit(Event("delayed 2000"))
+            }
+        )
+
+        eventSource.subscribe { eventsReceived.add(it) }
+
+        advanceTimeBy(501)
+        assertThat(eventsReceived).containsExactly(Event("delayed 500"))
+        advanceUntilIdle()
+        assertThat(eventsReceived).containsExactly(Event("delayed 500"), Event("delayed 2000"))
+    }
+
+    @Test
+    @Requirement(
+        given = "Event source from flows",
+        `when` = "a flow produces an event in a different context",
+        then = "the event is notified"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun flowInDifferentContexts() = runTest {
+        val eventsReceived = mutableListOf<Event>()
+        val flowDispatcher = StandardTestDispatcher(testScheduler)
+        val eventSource = FlowEventSources.fromFlows(
+            coroutineContext,
+            flowOf(Event("event1"))
+                .flowOn(flowDispatcher),
+        )
+
+        eventSource.subscribe { eventsReceived.add(it) }
+        advanceUntilIdle()
+
+        assertThat(eventsReceived).containsExactly(Event("event1"))
+    }
+
+    @Test
+    @Requirement(
+        given = "Event source from flows",
+        `when` = "event source is disposed",
+        then = "no more events are processed"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun eventSourceDisposed() = runTest {
+        val eventsReceived = mutableListOf<Event>()
+        val eventSource = FlowEventSources.fromFlows<Event>(
+            StandardTestDispatcher(testScheduler),
+            flow {
+                for (i in 1..20) {
+                    emit(Event("event $i"))
+                    delay(100)
+                }
+            }
+        )
+
+        val disposable = eventSource.subscribe { eventsReceived.add(it) }
+        advanceTimeBy(300)
+        disposable.dispose()
+        advanceUntilIdle()
+
+        assertThat(eventsReceived).containsExactly(
+            Event("event 1"),
+            Event("event 2"),
+            Event("event 3"),
+        )
+    }
+
+    @Test
+    @Requirement(
+        given = "Event source from flows containing a child event source transformed with asFlow()",
+        `when` = "the child event source produces an event",
+        then = "the event from the child event source are notified correctly"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun eventSourceEventsAreNotified() = runTest {
+        val eventsReceived = mutableListOf<Event>()
+        val eventSource = FlowEventSources.fromFlows<Event>(
+            StandardTestDispatcher(testScheduler),
+            EventSource<Event> { eventConsumer ->
+                eventConsumer.accept(Event("From Event Source"))
+                Disposable { }
+            }.asFlow()
+        )
+
+        val disposable = eventSource.subscribe { eventsReceived.add(it) }
+        advanceUntilIdle()
+        disposable.dispose()
+
+        assertThat(eventsReceived).containsExactly(Event("From Event Source"))
+    }
+
+    @Test
+    @Requirement(
+        given = "Event source from flows containing a child event source transformed with asFlow()",
+        `when` = "the parent event source is disposed",
+        then = "the child event source is also disposed"
+    )
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun eventSourceIsDisposedCorrectly() = runTest {
+        var disposeCalled = false
+        val eventSource = FlowEventSources.fromFlows(
+            StandardTestDispatcher(testScheduler),
+            EventSource<Event> {
+                Disposable { disposeCalled = true }
+            }.asFlow()
+        )
+
+        val disposable = eventSource.subscribe { }
+        advanceUntilIdle()
+        disposable.dispose()
+        advanceUntilIdle()
+
+        assertThat(disposeCalled).isTrue()
+    }
+
+    private data class Event(val id: String)
+}

--- a/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/Requirement.kt
+++ b/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/Requirement.kt
@@ -1,0 +1,9 @@
+package com.spotify.mobius.coroutines
+
+import java.lang.annotation.Inherited
+
+/** Annotation for defining Given-When-Then tests */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+@Inherited
+annotation class Requirement(val given: String, val `when`: String = "", val whenever: String = "", val then: String)

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,7 @@ pluginManagement {
 rootProject.name = 'mobius'
 
 include 'mobius-core'
+include 'mobius-coroutines'
 include 'mobius-test'
 include 'mobius-rx'
 include 'mobius-rx2'


### PR DESCRIPTION
This adds a new tiny library called mobius-coroutines with utilities to use Mobius with kotlin Coroutines.
 
It contains 3 main functionalities for now:

- DispatcherWorker: A WorkRunner backed by a given specific CoroutineContext. 

```kotlin
    Mobius.loop(...)
            .effectRunner { DispatcherWorker(Dispatchers.IO) }
            .eventRunner { DispatcherWorker(Dispatchers.Default) }
```

- FlowEventSources: Utilities functions to create a EventSource from several Flows, or to transform a current EventSource into a Flow

```kotlin
    Mobius.loop(...)
            .eventSource (
                FlowEventSources.fromFlows(
                    Dispatchers.Default,
                    flow1.flowOn(Dispatchers.Main),
                    flow2,
                    oldEventSource.asFlow()
                ) 
            )
```

- CoroutinesSubtypeEffectHandler: similar to RxMobius.SubtypeEffectHandler, maps Event types to specific handlers, allowing suspend functions and flows to be use as handlers
 
```kotlin
    Mobius.loop(
        Update(...),
        MobiusCoroutines.subtypeEffectHandler<Effect, Event>()
          .addAction<Effect1> { ... }
          .addConsumer<Effect2> { effect -> ...  }
          .addFunction<Effect3> { effect -> event  }
          .addFlowProducer<Effect4> { effect ->
              flow {
                  emit(startingEvent)
                  ...
                  emit(endEvent)
              }
         }
    )
```