### PR TITLE
Add "addProducer" function into CoroutinesSubtypeEffectHandlerBuilder

### DIFF
--- a/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/CoroutinesSubtypeEffectHandlerBuilder.kt
+++ b/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/CoroutinesSubtypeEffectHandlerBuilder.kt
@@ -39,6 +39,13 @@ class CoroutinesSubtypeEffectHandlerBuilder<F : Any, E : Any> {
         flowOf()
     }
 
+    inline fun <reified G : F> addProducer(
+        crossinline producer: suspend () -> E
+    ) = addFlowProducer<G> {
+        val event = producer.invoke()
+        flowOf(event)
+    }
+
     inline fun <reified G : F> addFunction(
         crossinline function: suspend (G) -> E
     ): CoroutinesSubtypeEffectHandlerBuilder<F, E> = addFlowProducer<G> { effect ->

--- a/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/DispatcherWorkerTest.kt
+++ b/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/DispatcherWorkerTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertThrows
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class DispatcherWorkerTest {
 
     @Test
@@ -20,7 +21,6 @@ class DispatcherWorkerTest {
         `when` = "a work is post",
         then = "the work is processed"
     )
-    @ExperimentalCoroutinesApi
     fun postedWorkIsProcessed() = runTest {
         val worker = DispatcherWorker(coroutineContext)
         var taskProcessed = false
@@ -37,7 +37,6 @@ class DispatcherWorkerTest {
         `when` = "a work is post throwing an exception",
         then = "the exception is propagated"
     )
-    @ExperimentalCoroutinesApi
     fun exceptionsArePropagated() {
         assertThrows("Exception in work", RuntimeException::class.java) {
             runTest {
@@ -55,7 +54,6 @@ class DispatcherWorkerTest {
         `when` = "worker is disposed while a work is running",
         then = "the work is cancelled"
     )
-    @ExperimentalCoroutinesApi
     fun workIsCancelled() = runTest {
         var workStarted = false
         var workFinished = false
@@ -86,7 +84,6 @@ class DispatcherWorkerTest {
         `when` = "a work is post",
         then = "the work is not processed"
     )
-    @ExperimentalCoroutinesApi
     fun workOnDisposedWorker() = runTest {
         var workStarted = false
         val worker = DispatcherWorker(StandardTestDispatcher(testScheduler))

--- a/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/FlowEventSourcesTest.kt
+++ b/mobius-coroutines/src/test/java/com/spotify/mobius/coroutines/FlowEventSourcesTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.spotify.mobius.EventSource
 import com.spotify.mobius.coroutines.FlowEventSources.Companion.asFlow
 import com.spotify.mobius.disposables.Disposable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -14,6 +15,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class FlowEventSourcesTest {
 
     @Test
@@ -22,7 +24,6 @@ class FlowEventSourcesTest {
         `when` = "a flow produces an event",
         then = "the event is notified"
     )
-    @kotlinx.coroutines.ExperimentalCoroutinesApi
     fun eventIsNotified() = runTest {
         val eventsReceived = mutableListOf<Event>()
         val eventSource = FlowEventSources.fromFlows(
@@ -42,7 +43,6 @@ class FlowEventSourcesTest {
         `when` = "a flow produces an event after subscribe",
         then = "the event is notified"
     )
-    @kotlinx.coroutines.ExperimentalCoroutinesApi
     fun eventIsNotifiedAfterSubscribe() = runTest {
         val eventsReceived = mutableListOf<Event>()
         val eventSource = FlowEventSources.fromFlows<Event>(
@@ -67,7 +67,6 @@ class FlowEventSourcesTest {
         `when` = "any flow produces an event",
         then = "the event is notified immediately"
     )
-    @kotlinx.coroutines.ExperimentalCoroutinesApi
     fun multipleFlows() = runTest {
         val eventsReceived = mutableListOf<Event>()
         val eventSource = FlowEventSources.fromFlows<Event>(
@@ -96,7 +95,6 @@ class FlowEventSourcesTest {
         `when` = "a flow produces an event in a different context",
         then = "the event is notified"
     )
-    @kotlinx.coroutines.ExperimentalCoroutinesApi
     fun flowInDifferentContexts() = runTest {
         val eventsReceived = mutableListOf<Event>()
         val flowDispatcher = StandardTestDispatcher(testScheduler)
@@ -118,7 +116,6 @@ class FlowEventSourcesTest {
         `when` = "event source is disposed",
         then = "no more events are processed"
     )
-    @kotlinx.coroutines.ExperimentalCoroutinesApi
     fun eventSourceDisposed() = runTest {
         val eventsReceived = mutableListOf<Event>()
         val eventSource = FlowEventSources.fromFlows<Event>(
@@ -149,7 +146,6 @@ class FlowEventSourcesTest {
         `when` = "the child event source produces an event",
         then = "the event from the child event source are notified correctly"
     )
-    @kotlinx.coroutines.ExperimentalCoroutinesApi
     fun eventSourceEventsAreNotified() = runTest {
         val eventsReceived = mutableListOf<Event>()
         val eventSource = FlowEventSources.fromFlows<Event>(
@@ -173,7 +169,6 @@ class FlowEventSourcesTest {
         `when` = "the parent event source is disposed",
         then = "the child event source is also disposed"
     )
-    @kotlinx.coroutines.ExperimentalCoroutinesApi
     fun eventSourceIsDisposedCorrectly() = runTest {
         var disposeCalled = false
         val eventSource = FlowEventSources.fromFlows(


### PR DESCRIPTION
This PR introduces the method `addProducer` into `CoroutinesSubtypeEffectHandlerBuilder`.

This method is used to account for the cases where an `Effect` is consumed but ignored, like in the `addAction` method. But unlike the `addAction` method, and like the `addFunction` method, this new method is expected to produce an `Event`

Here are all the methods illustrated:

```kotlin
    Mobius.loop(
            Update(...),
            MobiusCoroutines.subtypeEffectHandler<Effect, Event>()
              .addAction<Effect1> { ... }
              .addConsumer<Effect2> { effect -> ...  }
              .addProducer<Effect3> {  event  }
              .addFunction<Effect4> { effect -> event  }
              .addFlowProducer<Effect5> { effect ->
                  flow {
                      emit(startingEvent)
                      ...
                      emit(endEvent)
                  }
             }
             .build()
        )
```

The new method is particularly useful when you are using method references instead of lambdas. Previously if you wanted to produce an event, you were required to use `addFunction` and declare your function with an unused parameter.

```kotlin
    Mobius.loop(
            Update(...),
            MobiusCoroutines.subtypeEffectHandler<Effect, Event>()
              .addProducer<Effect1>(::onEffect1)
              .addFunction<Effect2>(::onEffect2)
              .build()
        )

    fun onEffect1(): Event { ... }
    fun onEffect2(effect: Effect2): Event { ... }
``` 

Also, as a secondary minor task. I simplified the use of the annotation `@ExperimentalCoroutinesApi` in tests by moving it from every individual test to the test class. 