### PR TITLE
Add addFlow function to CoroutinesSubtypeEffectHandlerBuilder

### DIFF
--- a/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/CoroutinesSubtypeEffectHandlerBuilder.kt
+++ b/mobius-coroutines/src/main/java/com/spotify/mobius/coroutines/CoroutinesSubtypeEffectHandlerBuilder.kt
@@ -4,6 +4,8 @@ import com.spotify.mobius.Connectable
 import com.spotify.mobius.Connection
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KClass
@@ -51,6 +53,12 @@ class CoroutinesSubtypeEffectHandlerBuilder<F : Any, E : Any> {
     ): CoroutinesSubtypeEffectHandlerBuilder<F, E> = addFlowProducer<G> { effect ->
         val event = function.invoke(effect)
         flowOf(event)
+    }
+
+    inline fun <reified G : F> addFlow(
+        crossinline flowCollectorFunction: suspend FlowCollector<E>.(G) -> Unit
+    ): CoroutinesSubtypeEffectHandlerBuilder<F, E> = addFlowProducer<G> { effect ->
+        flow { flowCollectorFunction(effect) }
     }
 
     inline fun <reified G : F> addFlowProducer(


### PR DESCRIPTION
This PR introduces the method `addFlow` into `CoroutinesSubtypeEffectHandlerBuilder`.

This method allows to generate multiple `Event`s while consuming an `Effect`. The case was already contemplated by `addFlowProducer`, but the new method internally creates the flow giving a more succinct way to express the code handling the `Effect`.  

Here are all the methods illustrated:

```kotlin
    Mobius.loop(
            Update(...),
            MobiusCoroutines.subtypeEffectHandler<Effect, Event>()
              .addAction<Effect1> { ... }
              .addConsumer<Effect2> { effect -> ... }
              .addProducer<Effect3> { event }
              .addFunction<Effect4> { effect -> event }
              .addFlow<Effect5> { effect -> 
                  emit(startingEvent)
                  ...
                  emit(endEvent)
              }
              .addFlowProducer<Effect6> { effect ->
                  flow {
                      emit(startingEvent)
                      ...
                      emit(endEvent)
                  }
             }
             .build()
        )
```
