### PR TITLE
Remove ConcurrentHashMap to avoid Java8 problems on Android phones

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.0.1
+version=2.0.2
 
 GROUP=com.spotify.mobius
 


### PR DESCRIPTION
`ConcurrentHashMap` functions `computeIfAbsent` and `forEachValue` only available in Java 8. On Android, if desugaring for libraries is disabled, an app using this library crashes when the library tries to call those methods on phones with API < 6.1 

This code replaces the concurrent requirement from `computeIfAbsent` with a `Mutex`. There was no concurrency requirement for `forEachValue` since the code is executed after `scope.cancel()`.
