### PR TITLE
Add API to override default event and effect runners

### DIFF
--- a/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
@@ -25,9 +25,7 @@ import com.spotify.mobius.functions.Producer;
 import com.spotify.mobius.internal_util.ImmutableUtil;
 import com.spotify.mobius.runners.WorkRunner;
 import com.spotify.mobius.runners.WorkRunners;
-
 import java.util.Set;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 

--- a/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
@@ -23,6 +23,7 @@ import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
 
 import com.spotify.mobius.functions.Producer;
 import com.spotify.mobius.internal_util.ImmutableUtil;
+import com.spotify.mobius.runners.DefaultWorkRunners;
 import com.spotify.mobius.runners.WorkRunner;
 import com.spotify.mobius.runners.WorkRunners;
 import java.util.Locale;
@@ -109,14 +110,14 @@ public final class Mobius {
                 @Nonnull
                 @Override
                 public WorkRunner get() {
-                    return WorkRunners.singleThread();
+                    return DefaultWorkRunners.defaultEventRunner();
                 }
             },
             new Producer<>() {
                 @Nonnull
                 @Override
                 public WorkRunner get() {
-                    return WorkRunners.cachedThreadPool();
+                    return DefaultWorkRunners.defaultEffectRunner();
                 }
             });
   }

--- a/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
@@ -23,14 +23,11 @@ import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
 
 import com.spotify.mobius.functions.Producer;
 import com.spotify.mobius.internal_util.ImmutableUtil;
-import com.spotify.mobius.runners.DefaultWorkRunners;
 import com.spotify.mobius.runners.WorkRunner;
 import com.spotify.mobius.runners.WorkRunners;
-import java.util.Locale;
+
 import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicLong;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -106,20 +103,20 @@ public final class Mobius {
         null,
         (Connectable<M, E>) NOOP_EVENT_SOURCE,
         (MobiusLoop.Logger<M, E, F>) NOOP_LOGGER,
-            new Producer<>() {
-                @Nonnull
-                @Override
-                public WorkRunner get() {
-                    return DefaultWorkRunners.defaultEventRunner();
-                }
-            },
-            new Producer<>() {
-                @Nonnull
-                @Override
-                public WorkRunner get() {
-                    return DefaultWorkRunners.defaultEffectRunner();
-                }
-            });
+        new Producer<WorkRunner>() {
+          @Nonnull
+          @Override
+          public WorkRunner get() {
+            return MobiusPlugins.defaultEventRunner();
+          }
+        },
+        new Producer<WorkRunner>() {
+          @Nonnull
+          @Override
+          public WorkRunner get() {
+            return MobiusPlugins.defaultEffectRunner();
+          }
+        });
   }
 
   /**

--- a/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/Mobius.java
@@ -105,20 +105,20 @@ public final class Mobius {
         null,
         (Connectable<M, E>) NOOP_EVENT_SOURCE,
         (MobiusLoop.Logger<M, E, F>) NOOP_LOGGER,
-        new Producer<WorkRunner>() {
-          @Nonnull
-          @Override
-          public WorkRunner get() {
-            return WorkRunners.from(Executors.newSingleThreadExecutor(Builder.THREAD_FACTORY));
-          }
-        },
-        new Producer<WorkRunner>() {
-          @Nonnull
-          @Override
-          public WorkRunner get() {
-            return WorkRunners.from(Executors.newCachedThreadPool(Builder.THREAD_FACTORY));
-          }
-        });
+            new Producer<>() {
+                @Nonnull
+                @Override
+                public WorkRunner get() {
+                    return WorkRunners.singleThread();
+                }
+            },
+            new Producer<>() {
+                @Nonnull
+                @Override
+                public WorkRunner get() {
+                    return WorkRunners.cachedThreadPool();
+                }
+            });
   }
 
   /**
@@ -177,9 +177,6 @@ public final class Mobius {
   }
 
   static final class Builder<M, E, F> implements MobiusLoop.Builder<M, E, F> {
-
-    private static final MyThreadFactory THREAD_FACTORY = new MyThreadFactory();
-
     private final Update<M, E, F> update;
     private final Connectable<F, E> effectHandler;
     @Nullable private final Init<M, F> init;
@@ -319,21 +316,6 @@ public final class Mobius {
           eventSource,
           checkNotNull(eventRunner.get()),
           checkNotNull(effectRunner.get()));
-    }
-
-    private static class MyThreadFactory implements ThreadFactory {
-
-      private static final AtomicLong threadCount = new AtomicLong(0);
-
-      @Override
-      public Thread newThread(Runnable runnable) {
-        Thread thread = Executors.defaultThreadFactory().newThread(checkNotNull(runnable));
-
-        thread.setName(
-            String.format(Locale.ENGLISH, "mobius-thread-%d", threadCount.incrementAndGet()));
-
-        return thread;
-      }
     }
   }
 }

--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusPlugins.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusPlugins.java
@@ -1,9 +1,12 @@
-package com.spotify.mobius.runners;
+package com.spotify.mobius;
+
+import com.spotify.mobius.runners.WorkRunner;
+import com.spotify.mobius.runners.WorkRunners;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class DefaultWorkRunners {
+public class MobiusPlugins {
 
     @Nullable
     private static WorkRunner EFFECT_RUNNER_OVERRIDE;
@@ -19,7 +22,7 @@ public class DefaultWorkRunners {
     }
 
     @Nonnull
-    public static WorkRunner defaultEffectRunner() {
+    static WorkRunner defaultEffectRunner() {
         if (EFFECT_RUNNER_OVERRIDE != null) {
             return EFFECT_RUNNER_OVERRIDE;
         }
@@ -27,7 +30,7 @@ public class DefaultWorkRunners {
     }
 
     @Nonnull
-    public static WorkRunner defaultEventRunner() {
+    static WorkRunner defaultEventRunner() {
         if (EVENT_RUNNER_OVERRIDE != null) {
             return EVENT_RUNNER_OVERRIDE;
         }

--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusPlugins.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusPlugins.java
@@ -13,10 +13,22 @@ public class MobiusPlugins {
     @Nullable
     private static WorkRunner EVENT_RUNNER_OVERRIDE;
 
+    /**
+     * Sets the effect runner that will be used in {@link MobiusLoop} when effectRunner was not
+     * provided to {@link MobiusLoop.Builder}.
+     *
+     * @param defaultEffectRunner the {@link WorkRunner} to use as the default effect runner
+     */
     public static void setDefaultEffectRunner(WorkRunner defaultEffectRunner) {
         EFFECT_RUNNER_OVERRIDE = defaultEffectRunner;
     }
 
+    /**
+     * Sets the event runner that will be used in {@link MobiusLoop} when eventRunner was not
+     * provided to {@link MobiusLoop.Builder}.
+     *
+     * @param defaultEventRunner the {@link WorkRunner} to use as the default event runner
+     */
     public static void setDefaultEventRunner(WorkRunner defaultEventRunner) {
         EVENT_RUNNER_OVERRIDE = defaultEventRunner;
     }

--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusPlugins.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusPlugins.java
@@ -2,50 +2,47 @@ package com.spotify.mobius;
 
 import com.spotify.mobius.runners.WorkRunner;
 import com.spotify.mobius.runners.WorkRunners;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class MobiusPlugins {
 
-    @Nullable
-    private static WorkRunner EFFECT_RUNNER_OVERRIDE;
-    @Nullable
-    private static WorkRunner EVENT_RUNNER_OVERRIDE;
+  @Nullable private static WorkRunner EFFECT_RUNNER_OVERRIDE;
+  @Nullable private static WorkRunner EVENT_RUNNER_OVERRIDE;
 
-    /**
-     * Sets the effect runner that will be used in {@link MobiusLoop} when effectRunner was not
-     * provided to {@link MobiusLoop.Builder}.
-     *
-     * @param defaultEffectRunner the {@link WorkRunner} to use as the default effect runner
-     */
-    public static void setDefaultEffectRunner(WorkRunner defaultEffectRunner) {
-        EFFECT_RUNNER_OVERRIDE = defaultEffectRunner;
-    }
+  /**
+   * Sets the effect runner that will be used in {@link MobiusLoop} when effectRunner was not
+   * provided to {@link MobiusLoop.Builder}.
+   *
+   * @param defaultEffectRunner the {@link WorkRunner} to use as the default effect runner
+   */
+  public static void setDefaultEffectRunner(WorkRunner defaultEffectRunner) {
+    EFFECT_RUNNER_OVERRIDE = defaultEffectRunner;
+  }
 
-    /**
-     * Sets the event runner that will be used in {@link MobiusLoop} when eventRunner was not
-     * provided to {@link MobiusLoop.Builder}.
-     *
-     * @param defaultEventRunner the {@link WorkRunner} to use as the default event runner
-     */
-    public static void setDefaultEventRunner(WorkRunner defaultEventRunner) {
-        EVENT_RUNNER_OVERRIDE = defaultEventRunner;
-    }
+  /**
+   * Sets the event runner that will be used in {@link MobiusLoop} when eventRunner was not provided
+   * to {@link MobiusLoop.Builder}.
+   *
+   * @param defaultEventRunner the {@link WorkRunner} to use as the default event runner
+   */
+  public static void setDefaultEventRunner(WorkRunner defaultEventRunner) {
+    EVENT_RUNNER_OVERRIDE = defaultEventRunner;
+  }
 
-    @Nonnull
-    static WorkRunner defaultEffectRunner() {
-        if (EFFECT_RUNNER_OVERRIDE != null) {
-            return EFFECT_RUNNER_OVERRIDE;
-        }
-        return WorkRunners.cachedThreadPool();
+  @Nonnull
+  static WorkRunner defaultEffectRunner() {
+    if (EFFECT_RUNNER_OVERRIDE != null) {
+      return EFFECT_RUNNER_OVERRIDE;
     }
+    return WorkRunners.cachedThreadPool();
+  }
 
-    @Nonnull
-    static WorkRunner defaultEventRunner() {
-        if (EVENT_RUNNER_OVERRIDE != null) {
-            return EVENT_RUNNER_OVERRIDE;
-        }
-        return WorkRunners.singleThread();
+  @Nonnull
+  static WorkRunner defaultEventRunner() {
+    if (EVENT_RUNNER_OVERRIDE != null) {
+      return EVENT_RUNNER_OVERRIDE;
     }
+    return WorkRunners.singleThread();
+  }
 }

--- a/mobius-core/src/main/java/com/spotify/mobius/MobiusPlugins.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/MobiusPlugins.java
@@ -1,3 +1,22 @@
+/*
+ * -\-\-
+ * Mobius
+ * --
+ * Copyright (c) 2017-2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.mobius;
 
 import com.spotify.mobius.runners.WorkRunner;

--- a/mobius-core/src/main/java/com/spotify/mobius/runners/DefaultWorkRunners.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/runners/DefaultWorkRunners.java
@@ -1,12 +1,36 @@
 package com.spotify.mobius.runners;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public class DefaultWorkRunners {
 
+    @Nullable
+    private static WorkRunner EFFECT_RUNNER_OVERRIDE;
+    @Nullable
+    private static WorkRunner EVENT_RUNNER_OVERRIDE;
+
+    public static void setDefaultEffectRunner(WorkRunner defaultEffectRunner) {
+        EFFECT_RUNNER_OVERRIDE = defaultEffectRunner;
+    }
+
+    public static void setDefaultEventRunner(WorkRunner defaultEventRunner) {
+        EVENT_RUNNER_OVERRIDE = defaultEventRunner;
+    }
+
+    @Nonnull
     public static WorkRunner defaultEffectRunner() {
+        if (EFFECT_RUNNER_OVERRIDE != null) {
+            return EFFECT_RUNNER_OVERRIDE;
+        }
         return WorkRunners.cachedThreadPool();
     }
 
+    @Nonnull
     public static WorkRunner defaultEventRunner() {
+        if (EVENT_RUNNER_OVERRIDE != null) {
+            return EVENT_RUNNER_OVERRIDE;
+        }
         return WorkRunners.singleThread();
     }
 }

--- a/mobius-core/src/main/java/com/spotify/mobius/runners/DefaultWorkRunners.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/runners/DefaultWorkRunners.java
@@ -1,0 +1,12 @@
+package com.spotify.mobius.runners;
+
+public class DefaultWorkRunners {
+
+    public static WorkRunner defaultEffectRunner() {
+        return WorkRunners.cachedThreadPool();
+    }
+
+    public static WorkRunner defaultEventRunner() {
+        return WorkRunners.singleThread();
+    }
+}

--- a/mobius-core/src/main/java/com/spotify/mobius/runners/WorkRunners.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/runners/WorkRunners.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
-
 import javax.annotation.Nonnull;
 
 /**
@@ -72,7 +71,7 @@ public class WorkRunners {
       Thread thread = Executors.defaultThreadFactory().newThread(checkNotNull(runnable));
 
       thread.setName(
-              String.format(Locale.ENGLISH, "mobius-thread-%d", threadCount.incrementAndGet()));
+          String.format(Locale.ENGLISH, "mobius-thread-%d", threadCount.incrementAndGet()));
 
       return thread;
     }

--- a/mobius-core/src/main/java/com/spotify/mobius/runners/WorkRunners.java
+++ b/mobius-core/src/main/java/com/spotify/mobius/runners/WorkRunners.java
@@ -21,8 +21,12 @@ package com.spotify.mobius.runners;
 
 import static com.spotify.mobius.internal_util.Preconditions.checkNotNull;
 
+import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -39,21 +43,38 @@ public class WorkRunners {
 
   @Nonnull
   public static WorkRunner singleThread() {
-    return from(Executors.newSingleThreadExecutor());
+    return from(Executors.newSingleThreadExecutor(THREAD_FACTORY));
   }
 
   @Nonnull
   public static WorkRunner fixedThreadPool(int n) {
-    return from(Executors.newFixedThreadPool(n));
+    return from(Executors.newFixedThreadPool(n, THREAD_FACTORY));
   }
 
   @Nonnull
   public static WorkRunner cachedThreadPool() {
-    return from(Executors.newCachedThreadPool());
+    return from(Executors.newCachedThreadPool(THREAD_FACTORY));
   }
 
   @Nonnull
   public static WorkRunner from(ExecutorService service) {
     return new ExecutorServiceWorkRunner(checkNotNull(service));
+  }
+
+  private static final MyThreadFactory THREAD_FACTORY = new MyThreadFactory();
+
+  private static class MyThreadFactory implements ThreadFactory {
+
+    private static final AtomicLong threadCount = new AtomicLong(0);
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+      Thread thread = Executors.defaultThreadFactory().newThread(checkNotNull(runnable));
+
+      thread.setName(
+              String.format(Locale.ENGLISH, "mobius-thread-%d", threadCount.incrementAndGet()));
+
+      return thread;
+    }
   }
 }


### PR DESCRIPTION
When there is no effect or event runner provided to the Mobius loop builder, the defaults will be used:
- `WorkRunners.from(Executors.newSingleThreadExecutor(...))` for events,
- `WorkRunners.from(Executors.newCachedThreadPool(...))` for effects.

Since those pools are created per loop instance it may result in creating a lot of threads, depending on the number of loops and their configuration. We want to be able to control this behaviour, thus add an API to be able to override the defaults:
```
MobiusPlugins.setDefaultEventRunner(defaultEventRunner);
MobiusPlugins.setDefaultEffectRunner(defaultEffectRunner);
```